### PR TITLE
CLI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,22 +81,16 @@ To make the same customized plot as in the library example, you can run:
 
 ```bash
 eor-limits plot-vs-k \
-    --limits=HERA2022 HERA2023 HERA2026 \
-    --bold-limits=HERA2026 \
+    --limits HERA2022 HERA2023 HERA2026 \
+    --bold-limits HERA2026 \
     --shade-limits \
-    --base-limit-style.linewidth=5 \
-    --base-limit-style.shade_alpha=0.1 \
-    --limit-styles.HERA2023.shade_alpha=0.25 \
-    --limit-styles.HERA2023.shade_color='C1' \
-    --theories=Mesinger2016Faint Mesinger2016Bright \
+    --base-limit-style '{"linewidth": 5, "shade_alpha": 0.1}' \
+    --limit-styles '{"HERA2023": {"shade_alpha": 0.25, "shade_color": "C1"}}' \
+    --theories Mesinger2016Faint Mesinger2016Bright \
     --shade-theories \
-    --base-theory-style.linestyle='-.' \
-    --theory-styles.Mesinger2016Faint.color='C3' \
-    --theory-styles.Mesinger2016Faint.shade_alpha=0.5 \
-    --theory-styles.Mesinger2016Faint.shade_color='C3' \
-    --theory-styles.Mesinger2016Bright.color='C4' \
-    --theory-styles.Mesinger2016Bright.shade_alpha=0.1 \
-    --theory-styles.Mesinger2016Bright.shade_color='C4' \
+    --base-theory-style '{"linestyle": "-."}' \
+    --theory-styles '{"Mesinger2016Faint": {"color": "C3", "shade_alpha": 0.5, "shade_color": "C3"},
+                     "Mesinger2016Bright": {"color": "C4", "shade_alpha": 0.1, "shade_color": "C4"}}' \
     --out MyPlot.pdf
 ```
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ After installation, you can also use the `eor-limits` command from the terminal 
 eor-limits plot-vs-k --out=MyPlot.pdf
 ```
 
-To make the same customized plot as in the library example, you can run:
+To make the same customized plot as in the library example, the command allows for JSON-style dictionaries as arguments for the various style options, so you can run:
 
 ```bash
 eor-limits plot-vs-k \

--- a/README.md
+++ b/README.md
@@ -12,22 +12,23 @@ To use the code, check out the _Usage and examples_. For users who want to quick
 
 ### User installation
 
-* Clone the repository using
-```git clone https://github.com/EoRImaging/eor_limits```
+* Clone the repository using ```git clone https://github.com/EoRImaging/eor_limits```
 
-* For a simple user installation, change directories into the `eor_limits` folder and
-run ```pip install .``` (including the dot).
+* For a simple user installation, change directories into the `eor_limits` folder and run ```pip install .``` (including the dot).
 
 * To install without dependencies, run `pip install --no-deps .` (including the dot).
 
 ### Developer installation
 
-* Developers who would like to contribute to the code can install the package as: ```pip install -e .[dev]``` (including the dot). This will install the package in editable mode, which allows you to make changes to the code and have them immediately reflected when you import the package. It will also install the development dependencies, which include tools for testing and formatting the code.
+* **pip installation**: Developers who would like to contribute to the code can install the package as: ```pip install -e .``` (including the dot). This will install the package in editable mode, which allows you to make changes to the code and have them immediately reflected when you import the package.
 
-* If you prefer to use `uv` to manage your environment, you can install the package in editable mode with the development dependencies using: ```uv sync --all-extras --editable .```
+* **uv installation**: If you prefer to use `uv` to manage your environment, you can install the package in editable mode with the development dependencies using: ```uv sync --all-extras --editable .```
 
-* To use pre-commit to prevent committing code that does not follow our style,
-you'll need to run `pre-commit install` in the top level `eor_limits` directory.
+* **Using pre-commit**: To use pre-commit to prevent committing code that does not follow our style, you'll need to run `pre-commit install` in the top level `eor_limits` directory.
+
+* **Testing**: To run the tests, you can use the command `pytest` from the top level `eor_limits` directory. If you have `uv` installed, you can also run the tests with the development dependencies using `uv run pytest`.
+
+* **CLI debugging**: To debug the CLI, append the environment variable `EOR_LIMITS_DEBUG=1` to the command you want to run, e.g. ```EOR_LIMITS_DEBUG=1 eor-limits plot-vs-k --out=MyPlot.pdf```. This will print out richly-formatted tracebacks instead of the high-level error messages.
 
 ## Usage and examples
 
@@ -77,7 +78,7 @@ After installation, you can also use the `eor-limits` command from the terminal 
 eor-limits plot-vs-k --out=MyPlot.pdf
 ```
 
-To make the same customized plot as in the library example, the command allows for JSON-style dictionaries as arguments for the various style options, so you can run:
+To make the same customized plot as in the library example, the command allows for JSON dictionaries as arguments for the various `-style` options, so you can run:
 
 ```bash
 eor-limits plot-vs-k \

--- a/src/eor_limits/_cli.py
+++ b/src/eor_limits/_cli.py
@@ -7,7 +7,6 @@ import functools
 import logging
 import os
 import sys
-from typing import Any
 
 from cyclopts import App, Parameter
 from rich.console import Console
@@ -53,43 +52,10 @@ class CLIError(Exception):
         )
 
 
-def _coerce_types(val: Any) -> Any:
-    """
-    Recursively convert string numbers to floats.
-
-    Cyclopts does not support nested dictionaries or Any types in its CLI arguments,
-    and all values are passed as strings. This function attempts to convert any string
-    that can be converted to a float, while leaving non-numeric strings unchanged.
-
-    Additionally, it tries to parse strings that look like JSON objects or arrays
-    to allow for more complex structures to be passed as command-line arguments.
-    """
-    if isinstance(val, str):
-        try:
-            return float(val)  # Try converting to float first
-        except ValueError:
-            return val  # Keep as string (colors, etc.)
-    if isinstance(val, dict):
-        return {k: _coerce_types(v) for k, v in val.items()}
-    if isinstance(val, list):
-        return [_coerce_types(v) for v in val]
-    return val
-
-
 @functools.wraps(_plot_vs_k)
 def plot_vs_k(*args, **kwargs):
     """CLI wrapper for plotting limits vs scale, k."""
     try:
-        dict_keys = [
-            "base_limit_style",
-            "limit_styles",
-            "base_theory_style",
-            "theory_styles",
-            "sensitivity_style",
-        ]
-        for key in dict_keys:
-            if kwargs.get(key):
-                kwargs[key] = _coerce_types(kwargs[key])
         _plot_vs_k(*args, **kwargs)
     except Exception as e:
         if os.getenv("EOR_LIMITS_DEBUG"):
@@ -103,16 +69,6 @@ def plot_vs_k(*args, **kwargs):
 def plot_vs_z(*args, **kwargs):
     """CLI wrapper for plotting limits vs scale, z."""
     try:
-        dict_keys = [
-            "base_limit_style",
-            "limit_styles",
-            "base_theory_style",
-            "theory_styles",
-            "sensitivity_style",
-        ]
-        for key in dict_keys:
-            if kwargs.get(key):
-                kwargs[key] = _coerce_types(kwargs[key])
         _plot_vs_z(*args, **kwargs)
     except Exception as e:
         if os.getenv("EOR_LIMITS_DEBUG"):

--- a/src/eor_limits/_cli.py
+++ b/src/eor_limits/_cli.py
@@ -9,7 +9,7 @@ import os
 import sys
 from typing import Any
 
-from cyclopts import App
+from cyclopts import App, Parameter
 from rich.console import Console
 from rich.logging import RichHandler
 from rich.panel import Panel
@@ -23,7 +23,10 @@ install(show_locals=True)
 app = App(
     help="A package for plotting and comparing "
     "21-cm power spectrum limits and theories.",
-    help_format="rich",
+    help_format="markdown",
+    # show_default=True shows [default: None] for all None-typed params
+    # negative="" remove the --empty options that cyclopts adds for None-typed params
+    default_parameter=Parameter(show_default=True, negative=""),
 )
 logger = logging.getLogger("eor_limits")
 logging.basicConfig(

--- a/src/eor_limits/_plot.py
+++ b/src/eor_limits/_plot.py
@@ -1,6 +1,8 @@
 """Module defining a plotting function for EoR limits vs k and redshift."""
 
+import json
 import logging
+from collections.abc import Sequence
 from itertools import chain
 from pathlib import Path
 from typing import Annotated, Any
@@ -10,7 +12,7 @@ import matplotlib.cm as cmx
 import matplotlib.colors as colors
 import matplotlib.pyplot as plt
 import numpy as np
-from cyclopts import Parameter
+from cyclopts import Parameter, Token
 
 from ._data_loading import load_limit_data, load_theory_model
 from ._datatypes import DataSet
@@ -25,6 +27,15 @@ DEFAULT_TELESCOPE_MARKERS = {
 }
 
 
+def _json_str_to_dict(type_, tokens: Sequence[Token]) -> dict:
+    """Convert a JSON string to a dictionary."""
+    try:
+        json_str = tokens[0].value
+        return json.loads(json_str) if json_str else {}
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON string: {json_str}") from e
+
+
 def plot_vs_z(*args, **kwargs):
     """
     Plot 21-cm power spectrum limits as a function of redshift, z.
@@ -37,8 +48,12 @@ def plot_vs_z(*args, **kwargs):
 def plot_vs_k(
     # Limit plotting options
     limits: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
-    base_limit_style: dict[str, Any] | None = None,
-    limit_styles: dict[str, dict[str, Any]] | None = None,
+    base_limit_style: Annotated[
+        dict[str, Any] | None, Parameter(converter=_json_str_to_dict)
+    ] = None,
+    limit_styles: Annotated[
+        dict[str, dict[str, Any]] | None, Parameter(converter=_json_str_to_dict)
+    ] = None,
     bold_limits: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
     shade_limits: bool = True,
     aspoints: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
@@ -51,8 +66,12 @@ def plot_vs_k(
     # Theory plotting options
     theories: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
     theory_redshifts: dict[str, list[float]] | None = None,
-    base_theory_style: dict[str, Any] | None = None,
-    theory_styles: dict[str, dict[str, Any]] | None = None,
+    base_theory_style: Annotated[
+        dict[str, Any] | None, Parameter(converter=_json_str_to_dict)
+    ] = None,
+    theory_styles: Annotated[
+        dict[str, dict[str, Any]] | None, Parameter(converter=_json_str_to_dict)
+    ] = None,
     bold_theories: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
     shade_theories: bool = True,
     # Sensitivity plotting options

--- a/src/eor_limits/_plot.py
+++ b/src/eor_limits/_plot.py
@@ -45,7 +45,7 @@ JsonNestedDict = Annotated[
 
 def plot_vs_z(*args, **kwargs):
     """
-    Plot 21-cm power spectrum limits as a function of redshift, z.
+    Plot 21-cm power spectrum limits as a function of redshift |z|.
 
     Not yet implemented. Stay tuned!
     """

--- a/src/eor_limits/_plot.py
+++ b/src/eor_limits/_plot.py
@@ -36,6 +36,13 @@ def _json_str_to_dict(type_, tokens: Sequence[Token]) -> dict:
         raise ValueError(f"Invalid JSON string: {json_str}") from e
 
 
+StrList = Annotated[list[str] | None, Parameter(consume_multiple=True)]
+JsonDict = Annotated[dict[str, Any] | None, Parameter(converter=_json_str_to_dict)]
+JsonNestedDict = Annotated[
+    dict[str, dict[str, Any]] | None, Parameter(converter=_json_str_to_dict)
+]
+
+
 def plot_vs_z(*args, **kwargs):
     """
     Plot 21-cm power spectrum limits as a function of redshift, z.
@@ -47,32 +54,24 @@ def plot_vs_z(*args, **kwargs):
 
 def plot_vs_k(
     # Limit plotting options
-    limits: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
-    base_limit_style: Annotated[
-        dict[str, Any] | None, Parameter(converter=_json_str_to_dict)
-    ] = None,
-    limit_styles: Annotated[
-        dict[str, dict[str, Any]] | None, Parameter(converter=_json_str_to_dict)
-    ] = None,
-    bold_limits: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
+    limits: StrList = None,
+    base_limit_style: JsonDict = None,
+    limit_styles: JsonNestedDict = None,
+    bold_limits: StrList = None,
     shade_limits: bool = True,
-    aspoints: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
-    aslines: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
+    aspoints: StrList = None,
+    aslines: StrList = None,
     nk_for_lines: int = 10,
     # Limits selection options
     z_range: tuple[float, float] | None = None,
     k_range: tuple[float, float] | None = None,
     delta_squared_range: tuple[float, float] | None = None,
     # Theory plotting options
-    theories: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
+    theories: StrList = None,
     theory_redshifts: dict[str, list[float]] | None = None,
-    base_theory_style: Annotated[
-        dict[str, Any] | None, Parameter(converter=_json_str_to_dict)
-    ] = None,
-    theory_styles: Annotated[
-        dict[str, dict[str, Any]] | None, Parameter(converter=_json_str_to_dict)
-    ] = None,
-    bold_theories: Annotated[list[str] | None, Parameter(consume_multiple=True)] = None,
+    base_theory_style: JsonDict = None,
+    theory_styles: JsonNestedDict = None,
+    bold_theories: StrList = None,
     shade_theories: bool = True,
     # Sensitivity plotting options
     sensitivities: dict | None = None,

--- a/src/eor_limits/_plot.py
+++ b/src/eor_limits/_plot.py
@@ -199,9 +199,9 @@ def plot_vs_k(
         fig_height = fig_width * (fig_ratio or 0.5)
 
     if fig is None or ax is None:
-        fig = plt.figure(figsize=(fig_width, fig_height))
+        fig, ax = plt.subplots(figsize=(fig_width, fig_height))
     elif ax is not None:
-        plt.sca(ax)
+        fig = ax.get_figure()
 
     ###################################################################################
     # OBSERVATIONAL LIMITS
@@ -273,6 +273,7 @@ def plot_vs_k(
     # Plotting the limits as points or lines, depending on the number of k values
     # or user specifications.
     limit_lines = plot_limits(
+        ax,
         limits,
         limit_styles,
         limit_labels,
@@ -314,6 +315,7 @@ def plot_vs_k(
 
     # Plotting the theory lines.
     theory_lines = plot_theories(
+        ax,
         theories,
         theory_styles,
         theory_labels,
@@ -331,27 +333,25 @@ def plot_vs_k(
     sensitivity_style = build_sensitivity_styles(sensitivities, sensitivity_style)
 
     # Plot the sensitivity curves.
-    plot_sensitivities(sensitivities, sensitivity_style, fontsize)
+    plot_sensitivities(ax, sensitivities, sensitivity_style, fontsize)
 
     ###################################################################################
     # PLOT ADJUSTMENTS
 
     plt.rcParams.update({"font.size": fontsize})
-    plt.xlabel(r"k ($h Mpc^{-1}$)", fontsize=fontsize)
-    plt.ylabel(r"$\Delta^2$ ($mK^2$)", fontsize=fontsize)
-    plt.yscale("log")
-    plt.xscale("log")
-    plt.ylim(*delta_squared_range)
-    plt.xlim(*k_range)
+    ax.set_xlabel(r"k ($h Mpc^{-1}$)", fontsize=fontsize)
+    ax.set_ylabel(r"$\Delta^2$ ($mK^2$)", fontsize=fontsize)
+    ax.set_yscale("log")
+    ax.set_xscale("log")
+    ax.set_ylim(*delta_squared_range)
+    ax.set_xlim(*k_range)
 
-    plt.tick_params(labelsize=fontsize)
-    cb = plt.colorbar(
-        scalar_map, ax=plt.gca(), fraction=0.1, pad=0.08, label="Redshift"
-    )
+    ax.tick_params(labelsize=fontsize)
+    cb = fig.colorbar(scalar_map, ax=ax, fraction=0.1, pad=0.08, label="Redshift")
     cb.ax.yaxis.set_label_position("left")
     cb.ax.yaxis.set_ticks_position("left")
     cb.set_label(label="Redshift", fontsize=fontsize)
-    plt.grid(axis="y")
+    ax.grid(axis="y")
 
     if fontsize > 25:
         leg_columns = 1
@@ -372,7 +372,7 @@ def plot_vs_k(
     axis_height_norm = axis_height / fig_height
     plot_bottom = legend_height_norm + axis_height_norm
 
-    plt.legend(
+    ax.legend(
         limit_lines + theory_lines,
         limit_labels + theory_labels,
         bbox_to_anchor=(0.48, legend_height_norm / 2.0),
@@ -382,7 +382,7 @@ def plot_vs_k(
         frameon=False,
     )
 
-    plt.subplots_adjust(bottom=plot_bottom)
+    fig.subplots_adjust(bottom=plot_bottom)
     fig.tight_layout()
 
     if out is not None:
@@ -596,6 +596,7 @@ def get_latex_theory_label(paper: DataSet, bold: bool = False) -> str:
 
 
 def plot_limits(
+    ax: plt.Axes,
     limits: list[DataSet],
     limit_styles: dict[str, dict[str, Any]],
     limit_labels: list[str],
@@ -603,7 +604,7 @@ def plot_limits(
     delta_squared_range: tuple[float, float],
     scalar_map: cmx.ScalarMappable,
 ):
-    """Plot limit papers on the current plot."""
+    """Plot limit papers on the given axes."""
     lines = []
 
     for limit, label in zip(limits, limit_labels, strict=True):
@@ -631,7 +632,7 @@ def plot_limits(
                 )
             )
 
-            line = plt.scatter(
+            line = ax.scatter(
                 k,
                 dsq,
                 color=scalar_map.to_rgba(z),
@@ -653,7 +654,7 @@ def plot_limits(
                 ):
                     k_edges = np.concatenate((klow, [khi[-1]]))
                     delta_edges = np.concatenate((dsq, dsq[-1:]))
-                    plt.fill_between(
+                    ax.fill_between(
                         k_edges,
                         delta_edges,
                         delta_squared_range[1],
@@ -696,7 +697,7 @@ def plot_limits(
                 color_val = scalar_map.to_rgba(redshift)
 
                 # make black outline by plotting thicker black line first
-                plt.plot(
+                ax.plot(
                     k_edges,
                     delta_edges,
                     color="black",
@@ -704,7 +705,7 @@ def plot_limits(
                     zorder=1,
                 )
 
-                (this_line,) = plt.plot(
+                (this_line,) = ax.plot(
                     k_edges,
                     delta_edges,
                     color=color_val,
@@ -713,7 +714,7 @@ def plot_limits(
                     **limit_style,
                 )
                 if shade_limits:
-                    plt.fill_between(
+                    ax.fill_between(
                         k_edges,
                         delta_edges,
                         delta_squared_range[1],
@@ -731,13 +732,14 @@ def plot_limits(
 
 
 def plot_theories(
+    ax: plt.Axes,
     theories: list[DataSet],
     theory_styles: dict[str, dict[str, Any]],
     theory_labels: list[str],
     shade_theories: bool,
     delta_squared_range: tuple[float, float],
 ):
-    """Plot theory lines on the current plot."""
+    """Plot theory lines on the given axes."""
     lines = []
 
     for theory, label in zip(theories, theory_labels, strict=True):
@@ -749,7 +751,7 @@ def plot_theories(
         if shade_theories:
             shade_alpha = theory_style.pop("shade_alpha")
             shade_color = theory_style.pop("shade_color")
-            plt.fill_between(
+            ax.fill_between(
                 theory.data.k[0],
                 theory.data.delta_squared[0],
                 delta_squared_range[0],
@@ -759,7 +761,7 @@ def plot_theories(
             )
 
         # Plot the theory line on top
-        (line,) = plt.plot(
+        (line,) = ax.plot(
             theory.data.k[0],
             theory.data.delta_squared[0],
             label=label,
@@ -772,8 +774,13 @@ def plot_theories(
     return lines
 
 
-def plot_sensitivities(sensitivities, sensitivity_style, fontsize):
-    """Plot the sensitivity curves."""
+def plot_sensitivities(
+    ax: plt.Axes,
+    sensitivities: dict[str, str] | None,
+    sensitivity_style: dict[str, dict[str, Any]] | None,
+    fontsize: int,
+):
+    """Plot the sensitivity curves on the given axes."""
     sensitivity_style = sensitivity_style or {}
     sensitivities = sensitivities or {}
     for indx, (name, fname) in enumerate(sensitivities.items()):
@@ -805,7 +812,7 @@ def plot_sensitivities(sensitivities, sensitivity_style, fontsize):
         ks = ks[~np.isinf(sense)]
         sense = sense[~np.isinf(sense)]
 
-        plt.plot(
+        ax.plot(
             ks,
             sense,
             color=style["color"],
@@ -817,6 +824,6 @@ def plot_sensitivities(sensitivities, sensitivity_style, fontsize):
         # We know the sensitivity will go up to the right, so we put it at about 2/3
         # of the way, and align it to top.
         k_ind = int(len(ks) * (0.8 - 0.1 * indx))
-        plt.text(
+        ax.text(
             ks[k_ind], sense[k_ind], name, fontsize=fontsize, verticalalignment="top"
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,16 @@
+"""Pytest configuration and fixtures for eor_limits tests.
+
+This module provides custom pytest hooks to control test execution order,
+ensuring that plotting tests run before CLI plotting tests for comparison
+of generated plots.
+"""
+
+
+def pytest_collection_modifyitems(items):
+    """Ensure test_plotting runs before test_cli_plotting."""
+    plotting_tests = [
+        i for i in items if "test_plotting" in i.nodeid and "cli" not in i.nodeid
+    ]
+    cli_tests = [i for i in items if "test_cli_plotting" in i.nodeid]
+    other_tests = [i for i in items if i not in plotting_tests and i not in cli_tests]
+    items[:] = other_tests + plotting_tests + cli_tests

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,9 @@ of generated plots.
 
 def pytest_collection_modifyitems(items):
     """Ensure test_plotting runs before test_cli_plotting."""
-    plotting_tests = [
-        i for i in items if "test_plotting" in i.nodeid and "cli" not in i.nodeid
+    lib_plot_tests = [i for i in items if "test_lib_plotting" in i.nodeid]
+    cli_plot_tests = [i for i in items if "test_cli_plotting" in i.nodeid]
+    other_tests = [
+        i for i in items if i not in lib_plot_tests and i not in cli_plot_tests
     ]
-    cli_tests = [i for i in items if "test_cli_plotting" in i.nodeid]
-    other_tests = [i for i in items if i not in plotting_tests and i not in cli_tests]
-    items[:] = other_tests + plotting_tests + cli_tests
+    items[:] = other_tests + lib_plot_tests + cli_plot_tests

--- a/tests/test_cli_plotting.py
+++ b/tests/test_cli_plotting.py
@@ -1,0 +1,159 @@
+"""Test CLI plotting commands."""
+
+from pathlib import Path
+
+import pytest
+
+import eor_limits
+from eor_limits._cli import app
+
+OUTPUT_DIR = Path(__file__).parent / "figures"
+OUTPUT_DIR.mkdir(exist_ok=True)
+
+# Tolerance for pixel-level image comparison (in RMS pixel units).
+IMAGE_TOL = 0.1
+
+
+def _run_plot_vs_k(*args: str) -> None:
+    """Invoke the CLI plot-vs-k command with provided args."""
+    with pytest.raises(SystemExit) as exc_info:
+        app(["plot-vs-k", *args], exit_on_error=False)
+    assert exc_info.value.code == 0
+
+
+def test_cli_app_exists():
+    """Test that the CLI app is properly instantiated."""
+    assert app is not None
+
+
+def test_cli_plot_vs_k_basic():
+    """Test making a plot with default parameters through the CLI."""
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_basic.pdf"
+    _run_plot_vs_k("--out", str(out))
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_fig_styling():
+    """Test making a plot with custom styling parameters through the CLI."""
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_fig_styling.pdf"
+    _run_plot_vs_k(
+        "--fontsize",
+        "12",
+        "--colormap",
+        "viridis",
+        "--fig-ratio",
+        "2.0",
+        "--out",
+        str(out),
+    )
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_z_range():
+    """Test making a plot with redshift range filtering through the CLI."""
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_z_range.pdf"
+    _run_plot_vs_k("--z-range", "6.0", "10.0", "--out", str(out))
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_k_range():
+    """Test making a plot with k range filtering through the CLI."""
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_k_range.pdf"
+    _run_plot_vs_k("--k-range", "0.1", "1.0", "--out", str(out))
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_delta_squared_range():
+    """Test making a plot with delta squared range filtering through the CLI."""
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_delta_squared_range.pdf"
+    _run_plot_vs_k("--delta-squared-range", "1e3", "1e5", "--out", str(out))
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_aspoints():
+    """Test making a plot with specific limits as points through the CLI."""
+    limits = list(eor_limits.KNOWN_LIMITS.keys())
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_aspoints.pdf"
+    _run_plot_vs_k(
+        "--limits",
+        *limits,
+        "--aspoints",
+        *limits,
+        "--out",
+        str(out),
+    )
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_aslines():
+    """Test making a plot with specific limits as lines through the CLI."""
+    limits = list(eor_limits.KNOWN_LIMITS.keys())
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_aslines.pdf"
+    _run_plot_vs_k(
+        "--limits",
+        *limits,
+        "--aslines",
+        *limits,
+        "--out",
+        str(out),
+    )
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_bold_limits():
+    """Test making a plot with bolded specific limits through the CLI."""
+    limits = list(eor_limits.KNOWN_LIMITS.keys())
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_bold_limits.pdf"
+    _run_plot_vs_k(
+        "--limits",
+        *limits,
+        "--bold-limits",
+        "HERA2022",
+        "HERA2023",
+        "--out",
+        str(out),
+    )
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_bold_theories():
+    """Test making a plot with bolded specific theories through the CLI."""
+    theories = list(eor_limits.KNOWN_THEORIES.keys())
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_bold_theories.pdf"
+    _run_plot_vs_k(
+        "--theories",
+        *theories,
+        "--bold-theories",
+        "Mesinger2016Faint",
+        "Mesinger2016Bright",
+        "--out",
+        str(out),
+    )
+    assert out.exists()
+
+
+def test_cli_plot_vs_k_with_limit_and_theory_styling():
+    """Test making a plot with custom limit/theory styling through the CLI."""
+    limits = list(eor_limits.KNOWN_LIMITS.keys())
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_limit_and_theory_styling.pdf"
+    _run_plot_vs_k(
+        "--limits",
+        *limits,
+        "--theories",
+        "Mesinger2016Faint",
+        "Mesinger2016Bright",
+        "--base-limit-style",
+        '{"linewidth": 5, "shade_alpha": 0.1}',
+        "--limit-styles",
+        '{"HERA2023": {"shade_alpha": 0.25, "shade_color": "C3"}}',
+        "--base-theory-style",
+        '{"linestyle": "-."}',
+        "--theory-styles",
+        '{"Mesinger2016Faint": {"color": "C0",\
+            "shade_alpha": 0.5, "shade_color": "C2"},\
+        "Mesinger2016Bright": {"color": "C1",\
+            "shade_alpha": 0.1, "shade_color": "C2"}}',
+        "--out",
+        str(out),
+    )
+    assert out.exists()

--- a/tests/test_cli_plotting.py
+++ b/tests/test_cli_plotting.py
@@ -15,11 +15,18 @@ OUTPUT_DIR.mkdir(exist_ok=True)
 IMAGE_TOL = 0.1
 
 
-def _run_plot_vs_k(*args: str) -> None:
+def _run_plot_vs_k(*args: str, expect_success: bool = True) -> None:
     """Invoke the CLI plot-vs-k command with provided args."""
     with pytest.raises(SystemExit) as exc_info:
-        app(["plot-vs-k", *args], exit_on_error=False)
-    assert exc_info.value.code == 0
+        app(["plot-vs-k", *args], exit_on_error=True)
+    if expect_success:
+        assert exc_info.value.code == 0
+        if "--out" in args:
+            out_index = args.index("--out") + 1
+            out_path = Path(args[out_index])
+            assert out_path.exists(), f"Expected output file not found: {out_path}"
+    else:
+        assert exc_info.value.code != 0  # negative test case
 
 
 def _assert_images_match(test_name: str, cli_path: Path) -> None:
@@ -48,8 +55,7 @@ def test_cli_app_exists():
 def test_cli_plot_vs_k_basic():
     """Test making a plot with default parameters through the CLI."""
     out = OUTPUT_DIR / "test_cli_plot_vs_k_basic.png"
-    _run_plot_vs_k("--out", str(out))
-    assert out.exists()
+    _run_plot_vs_k("--out", str(out), expect_success=True)
     _assert_images_match("basic", out)
 
 
@@ -65,32 +71,31 @@ def test_cli_plot_vs_k_with_fig_styling():
         "2.0",
         "--out",
         str(out),
+        expect_success=True,
     )
-    assert out.exists()
     _assert_images_match("with_fig_styling", out)
 
 
 def test_cli_plot_vs_k_with_z_range():
     """Test making a plot with redshift range filtering through the CLI."""
     out = OUTPUT_DIR / "test_cli_plot_vs_k_with_z_range.png"
-    _run_plot_vs_k("--z-range", "6.0", "10.0", "--out", str(out))
-    assert out.exists()
+    _run_plot_vs_k("--z-range", "6.0", "10.0", "--out", str(out), expect_success=True)
     _assert_images_match("with_z_range", out)
 
 
 def test_cli_plot_vs_k_with_k_range():
     """Test making a plot with k range filtering through the CLI."""
     out = OUTPUT_DIR / "test_cli_plot_vs_k_with_k_range.png"
-    _run_plot_vs_k("--k-range", "0.1", "1.0", "--out", str(out))
-    assert out.exists()
+    _run_plot_vs_k("--k-range", "0.1", "1.0", "--out", str(out), expect_success=True)
     _assert_images_match("with_k_range", out)
 
 
 def test_cli_plot_vs_k_with_delta_squared_range():
     """Test making a plot with delta squared range filtering through the CLI."""
     out = OUTPUT_DIR / "test_cli_plot_vs_k_with_delta_squared_range.png"
-    _run_plot_vs_k("--delta-squared-range", "1e3", "1e5", "--out", str(out))
-    assert out.exists()
+    _run_plot_vs_k(
+        "--delta-squared-range", "1e3", "1e5", "--out", str(out), expect_success=True
+    )
     _assert_images_match("with_delta_squared_range", out)
 
 
@@ -105,8 +110,8 @@ def test_cli_plot_vs_k_with_aspoints():
         *limits,
         "--out",
         str(out),
+        expect_success=True,
     )
-    assert out.exists()
     _assert_images_match("with_aspoints", out)
 
 
@@ -121,8 +126,8 @@ def test_cli_plot_vs_k_with_aslines():
         *limits,
         "--out",
         str(out),
+        expect_success=True,
     )
-    assert out.exists()
     _assert_images_match("with_aslines", out)
 
 
@@ -138,8 +143,8 @@ def test_cli_plot_vs_k_with_bold_limits():
         "HERA2023",
         "--out",
         str(out),
+        expect_success=True,
     )
-    assert out.exists()
     _assert_images_match("with_bold_limits", out)
 
 
@@ -155,14 +160,20 @@ def test_cli_plot_vs_k_with_bold_theories():
         "Mesinger2016Bright",
         "--out",
         str(out),
+        expect_success=True,
     )
-    assert out.exists()
     _assert_images_match("with_bold_theories", out)
 
 
 def test_cli_plot_vs_k_with_limit_and_theory_styling():
-    """Test making a plot with custom limit/theory styling through the CLI."""
+    """Test making a plot with custom limit/theory styling through the CLI.
+
+    Also exercises the error path for invalid JSON passed to style arguments,
+    asserting that the CLI exits non-zero and emits an informative message.
+    """
     limits = list(eor_limits.KNOWN_LIMITS.keys())
+
+    # Positive case: valid JSON style arguments work and produce an output file.
     out = OUTPUT_DIR / "test_cli_plot_vs_k_with_limit_and_theory_styling.png"
     _run_plot_vs_k(
         "--limits",
@@ -184,5 +195,19 @@ def test_cli_plot_vs_k_with_limit_and_theory_styling():
         "--out",
         str(out),
     )
-    assert out.exists()
     _assert_images_match("with_limit_and_theory_styling", out)
+
+    # Negative case: invalid JSON should trigger a non-zero exit and an error message.
+    bad_out = OUTPUT_DIR / "test_cli_plot_vs_k_with_invalid_style_json.png"
+    _run_plot_vs_k(
+        "--limits",
+        *limits,
+        "--theories",
+        "Mesinger2016Faint",
+        "Mesinger2016Bright",
+        "--base-limit-style",
+        '{"this-is": "not valid json",',  # Deliberately malformed JSON.
+        "--out",
+        str(bad_out),
+        expect_success=False,  # Negative test case
+    )

--- a/tests/test_cli_plotting.py
+++ b/tests/test_cli_plotting.py
@@ -28,7 +28,7 @@ def _assert_images_match(test_name: str, cli_path: Path) -> None:
     This helper skips the test if the reference image is missing, so CLI tests
     can be run in isolation without depending on test_plotting side effects.
     """
-    ref_path = OUTPUT_DIR / f"test_plot_vs_k_{test_name}.png"
+    ref_path = OUTPUT_DIR / f"test_lib_plot_vs_k_{test_name}.png"
     if not ref_path.exists():
         pytest.skip(
             f"Reference image not found: {ref_path}. "

--- a/tests/test_cli_plotting.py
+++ b/tests/test_cli_plotting.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from matplotlib.testing.compare import compare_images
 
 import eor_limits
 from eor_limits._cli import app
@@ -21,6 +22,17 @@ def _run_plot_vs_k(*args: str) -> None:
     assert exc_info.value.code == 0
 
 
+def _assert_images_match(test_name: str, cli_path: Path) -> None:
+    """Compare a CLI-generated PNG against the library-generated reference."""
+    ref_path = OUTPUT_DIR / f"test_plot_vs_k_{test_name}.png"
+    assert ref_path.exists(), (
+        f"Reference image not found: {ref_path}. "
+        "Ensure test_plotting runs before test_cli_plotting."
+    )
+    result = compare_images(str(ref_path), str(cli_path), tol=IMAGE_TOL)
+    assert result is None, result
+
+
 def test_cli_app_exists():
     """Test that the CLI app is properly instantiated."""
     assert app is not None
@@ -28,14 +40,15 @@ def test_cli_app_exists():
 
 def test_cli_plot_vs_k_basic():
     """Test making a plot with default parameters through the CLI."""
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_basic.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_basic.png"
     _run_plot_vs_k("--out", str(out))
     assert out.exists()
+    _assert_images_match("basic", out)
 
 
 def test_cli_plot_vs_k_with_fig_styling():
     """Test making a plot with custom styling parameters through the CLI."""
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_fig_styling.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_fig_styling.png"
     _run_plot_vs_k(
         "--fontsize",
         "12",
@@ -47,33 +60,37 @@ def test_cli_plot_vs_k_with_fig_styling():
         str(out),
     )
     assert out.exists()
+    _assert_images_match("with_fig_styling", out)
 
 
 def test_cli_plot_vs_k_with_z_range():
     """Test making a plot with redshift range filtering through the CLI."""
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_z_range.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_z_range.png"
     _run_plot_vs_k("--z-range", "6.0", "10.0", "--out", str(out))
     assert out.exists()
+    _assert_images_match("with_z_range", out)
 
 
 def test_cli_plot_vs_k_with_k_range():
     """Test making a plot with k range filtering through the CLI."""
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_k_range.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_k_range.png"
     _run_plot_vs_k("--k-range", "0.1", "1.0", "--out", str(out))
     assert out.exists()
+    _assert_images_match("with_k_range", out)
 
 
 def test_cli_plot_vs_k_with_delta_squared_range():
     """Test making a plot with delta squared range filtering through the CLI."""
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_delta_squared_range.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_delta_squared_range.png"
     _run_plot_vs_k("--delta-squared-range", "1e3", "1e5", "--out", str(out))
     assert out.exists()
+    _assert_images_match("with_delta_squared_range", out)
 
 
 def test_cli_plot_vs_k_with_aspoints():
     """Test making a plot with specific limits as points through the CLI."""
     limits = list(eor_limits.KNOWN_LIMITS.keys())
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_aspoints.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_aspoints.png"
     _run_plot_vs_k(
         "--limits",
         *limits,
@@ -83,12 +100,13 @@ def test_cli_plot_vs_k_with_aspoints():
         str(out),
     )
     assert out.exists()
+    _assert_images_match("with_aspoints", out)
 
 
 def test_cli_plot_vs_k_with_aslines():
     """Test making a plot with specific limits as lines through the CLI."""
     limits = list(eor_limits.KNOWN_LIMITS.keys())
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_aslines.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_aslines.png"
     _run_plot_vs_k(
         "--limits",
         *limits,
@@ -98,12 +116,13 @@ def test_cli_plot_vs_k_with_aslines():
         str(out),
     )
     assert out.exists()
+    _assert_images_match("with_aslines", out)
 
 
 def test_cli_plot_vs_k_with_bold_limits():
     """Test making a plot with bolded specific limits through the CLI."""
     limits = list(eor_limits.KNOWN_LIMITS.keys())
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_bold_limits.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_bold_limits.png"
     _run_plot_vs_k(
         "--limits",
         *limits,
@@ -114,12 +133,13 @@ def test_cli_plot_vs_k_with_bold_limits():
         str(out),
     )
     assert out.exists()
+    _assert_images_match("with_bold_limits", out)
 
 
 def test_cli_plot_vs_k_with_bold_theories():
     """Test making a plot with bolded specific theories through the CLI."""
     theories = list(eor_limits.KNOWN_THEORIES.keys())
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_bold_theories.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_bold_theories.png"
     _run_plot_vs_k(
         "--theories",
         *theories,
@@ -130,12 +150,13 @@ def test_cli_plot_vs_k_with_bold_theories():
         str(out),
     )
     assert out.exists()
+    _assert_images_match("with_bold_theories", out)
 
 
 def test_cli_plot_vs_k_with_limit_and_theory_styling():
     """Test making a plot with custom limit/theory styling through the CLI."""
     limits = list(eor_limits.KNOWN_LIMITS.keys())
-    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_limit_and_theory_styling.pdf"
+    out = OUTPUT_DIR / "test_cli_plot_vs_k_with_limit_and_theory_styling.png"
     _run_plot_vs_k(
         "--limits",
         *limits,
@@ -157,3 +178,4 @@ def test_cli_plot_vs_k_with_limit_and_theory_styling():
         str(out),
     )
     assert out.exists()
+    _assert_images_match("with_limit_and_theory_styling", out)

--- a/tests/test_cli_plotting.py
+++ b/tests/test_cli_plotting.py
@@ -23,12 +23,19 @@ def _run_plot_vs_k(*args: str) -> None:
 
 
 def _assert_images_match(test_name: str, cli_path: Path) -> None:
-    """Compare a CLI-generated PNG against the library-generated reference."""
+    """Compare a CLI-generated PNG against the library-generated reference.
+
+    This helper skips the test if the reference image is missing, so CLI tests
+    can be run in isolation without depending on test_plotting side effects.
+    """
     ref_path = OUTPUT_DIR / f"test_plot_vs_k_{test_name}.png"
-    assert ref_path.exists(), (
-        f"Reference image not found: {ref_path}. "
-        "Ensure test_plotting runs before test_cli_plotting."
-    )
+    if not ref_path.exists():
+        pytest.skip(
+            f"Reference image not found: {ref_path}. "
+            "Generate reference images via the plotting API before "
+            "running CLI image-comparison tests. "
+        )
+
     result = compare_images(str(ref_path), str(cli_path), tol=IMAGE_TOL)
     assert result is None, result
 

--- a/tests/test_lib_plotting.py
+++ b/tests/test_lib_plotting.py
@@ -9,95 +9,95 @@ OUTPUT_DIR = Path(__file__).parent / "figures"
 OUTPUT_DIR.mkdir(exist_ok=True)
 
 
-def test_plot_vs_k_basic():
+def test_lib_plot_vs_k_basic():
     """Test making a plot with default parameters."""
-    fig = plot_vs_k(out=OUTPUT_DIR / "test_plot_vs_k_basic.png")
+    fig = plot_vs_k(out=OUTPUT_DIR / "test_lib_plot_vs_k_basic.png")
     assert fig is not None
 
 
-def test_plot_vs_k_with_fig_styling():
+def test_lib_plot_vs_k_with_fig_styling():
     """Test making a plot with custom styling parameters."""
     fig = plot_vs_k(
         fontsize=12,
         colormap="viridis",
         fig_ratio=2.0,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_fig_styling.png",
+        out=OUTPUT_DIR / "test_lib_plot_vs_k_with_fig_styling.png",
     )
     assert fig is not None
 
 
-def test_plot_vs_k_with_z_range():
+def test_lib_plot_vs_k_with_z_range():
     """Test making a plot with redshift range filtering."""
     fig = plot_vs_k(
-        z_range=(6.0, 10.0), out=OUTPUT_DIR / "test_plot_vs_k_with_z_range.png"
+        z_range=(6.0, 10.0), out=OUTPUT_DIR / "test_lib_plot_vs_k_with_z_range.png"
     )
     assert fig is not None
 
 
-def test_plot_vs_k_with_k_range():
+def test_lib_plot_vs_k_with_k_range():
     """Test making a plot with k range filtering."""
     fig = plot_vs_k(
-        k_range=(0.1, 1.0), out=OUTPUT_DIR / "test_plot_vs_k_with_k_range.png"
+        k_range=(0.1, 1.0), out=OUTPUT_DIR / "test_lib_plot_vs_k_with_k_range.png"
     )
     assert fig is not None
 
 
-def test_plot_vs_k_with_delta_squared_range():
+def test_lib_plot_vs_k_with_delta_squared_range():
     """Test making a plot with delta_squared range filtering."""
     fig = plot_vs_k(
         delta_squared_range=(1e3, 1e5),
-        out=OUTPUT_DIR / "test_plot_vs_k_with_delta_squared_range.png",
+        out=OUTPUT_DIR / "test_lib_plot_vs_k_with_delta_squared_range.png",
     )
     assert fig is not None
 
 
-def test_plot_vs_k_with_aspoints():
+def test_lib_plot_vs_k_with_aspoints():
     """Test making a plot with specific limits as points."""
     limits = list(KNOWN_LIMITS.keys())
     fig = plot_vs_k(
         limits=limits,
         aspoints=limits,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_aspoints.png",
+        out=OUTPUT_DIR / "test_lib_plot_vs_k_with_aspoints.png",
     )
     assert fig is not None
 
 
-def test_plot_vs_k_with_aslines():
+def test_lib_plot_vs_k_with_aslines():
     """Test making a plot with specific limits as lines."""
     limits = list(KNOWN_LIMITS.keys())
     fig = plot_vs_k(
         limits=limits,
         aslines=limits,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_aslines.png",
+        out=OUTPUT_DIR / "test_lib_plot_vs_k_with_aslines.png",
     )
     assert fig is not None
 
 
-def test_plot_vs_k_with_bold_limits():
+def test_lib_plot_vs_k_with_bold_limits():
     """Test making a plot with bolded specific limits."""
     limits = list(KNOWN_LIMITS.keys())
     bold_limits = ["HERA2022", "HERA2023"]
     fig = plot_vs_k(
         limits=limits,
         bold_limits=bold_limits,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_bold_limits.png",
+        out=OUTPUT_DIR / "test_lib_plot_vs_k_with_bold_limits.png",
     )
     assert fig is not None
 
 
-def test_plot_vs_k_with_bold_theories():
+def test_lib_plot_vs_k_with_bold_theories():
     """Test making a plot with bolded specific theories."""
     theories = list(KNOWN_THEORIES.keys())
     bold_theories = ["Mesinger2016Faint", "Mesinger2016Bright"]
     fig = plot_vs_k(
         theories=theories,
         bold_theories=bold_theories,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_bold_theories.png",
+        out=OUTPUT_DIR / "test_lib_plot_vs_k_with_bold_theories.png",
     )
     assert fig is not None
 
 
-def test_plot_vs_k_with_limit_and_theory_styling():
+def test_lib_plot_vs_k_with_limit_and_theory_styling():
     """Test making a plot with custom styling parameters for limits and theories."""
     limits = list(KNOWN_LIMITS.keys())
     theories = ["Mesinger2016Faint", "Mesinger2016Bright"]
@@ -119,6 +119,6 @@ def test_plot_vs_k_with_limit_and_theory_styling():
                 "shade_color": "C2",
             },
         },
-        out=OUTPUT_DIR / "test_plot_vs_k_with_limit_and_theory_styling.png",
+        out=OUTPUT_DIR / "test_lib_plot_vs_k_with_limit_and_theory_styling.png",
     )
     assert fig is not None

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -3,21 +3,15 @@
 from pathlib import Path
 
 from eor_limits import KNOWN_LIMITS, KNOWN_THEORIES, plot_vs_k
-from eor_limits._cli import app
 
 # Output directory for test PDFs
 OUTPUT_DIR = Path(__file__).parent / "figures"
 OUTPUT_DIR.mkdir(exist_ok=True)
 
 
-def test_cli_app_exists():
-    """Test that the CLI app is properly instantiated."""
-    assert app is not None
-
-
 def test_plot_vs_k_basic():
     """Test making a plot with default parameters."""
-    fig = plot_vs_k()
+    fig = plot_vs_k(out=OUTPUT_DIR / "test_plot_vs_k_basic.pdf")
     assert fig is not None
 
 

--- a/tests/test_plotting.py
+++ b/tests/test_plotting.py
@@ -11,7 +11,7 @@ OUTPUT_DIR.mkdir(exist_ok=True)
 
 def test_plot_vs_k_basic():
     """Test making a plot with default parameters."""
-    fig = plot_vs_k(out=OUTPUT_DIR / "test_plot_vs_k_basic.pdf")
+    fig = plot_vs_k(out=OUTPUT_DIR / "test_plot_vs_k_basic.png")
     assert fig is not None
 
 
@@ -21,7 +21,7 @@ def test_plot_vs_k_with_fig_styling():
         fontsize=12,
         colormap="viridis",
         fig_ratio=2.0,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_fig_styling.pdf",
+        out=OUTPUT_DIR / "test_plot_vs_k_with_fig_styling.png",
     )
     assert fig is not None
 
@@ -29,7 +29,7 @@ def test_plot_vs_k_with_fig_styling():
 def test_plot_vs_k_with_z_range():
     """Test making a plot with redshift range filtering."""
     fig = plot_vs_k(
-        z_range=(6.0, 10.0), out=OUTPUT_DIR / "test_plot_vs_k_with_z_range.pdf"
+        z_range=(6.0, 10.0), out=OUTPUT_DIR / "test_plot_vs_k_with_z_range.png"
     )
     assert fig is not None
 
@@ -37,7 +37,7 @@ def test_plot_vs_k_with_z_range():
 def test_plot_vs_k_with_k_range():
     """Test making a plot with k range filtering."""
     fig = plot_vs_k(
-        k_range=(0.1, 1.0), out=OUTPUT_DIR / "test_plot_vs_k_with_k_range.pdf"
+        k_range=(0.1, 1.0), out=OUTPUT_DIR / "test_plot_vs_k_with_k_range.png"
     )
     assert fig is not None
 
@@ -46,7 +46,7 @@ def test_plot_vs_k_with_delta_squared_range():
     """Test making a plot with delta_squared range filtering."""
     fig = plot_vs_k(
         delta_squared_range=(1e3, 1e5),
-        out=OUTPUT_DIR / "test_plot_vs_k_with_delta_squared_range.pdf",
+        out=OUTPUT_DIR / "test_plot_vs_k_with_delta_squared_range.png",
     )
     assert fig is not None
 
@@ -57,7 +57,7 @@ def test_plot_vs_k_with_aspoints():
     fig = plot_vs_k(
         limits=limits,
         aspoints=limits,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_aspoints.pdf",
+        out=OUTPUT_DIR / "test_plot_vs_k_with_aspoints.png",
     )
     assert fig is not None
 
@@ -68,7 +68,7 @@ def test_plot_vs_k_with_aslines():
     fig = plot_vs_k(
         limits=limits,
         aslines=limits,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_aslines.pdf",
+        out=OUTPUT_DIR / "test_plot_vs_k_with_aslines.png",
     )
     assert fig is not None
 
@@ -80,7 +80,7 @@ def test_plot_vs_k_with_bold_limits():
     fig = plot_vs_k(
         limits=limits,
         bold_limits=bold_limits,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_bold_limits.pdf",
+        out=OUTPUT_DIR / "test_plot_vs_k_with_bold_limits.png",
     )
     assert fig is not None
 
@@ -92,7 +92,7 @@ def test_plot_vs_k_with_bold_theories():
     fig = plot_vs_k(
         theories=theories,
         bold_theories=bold_theories,
-        out=OUTPUT_DIR / "test_plot_vs_k_with_bold_theories.pdf",
+        out=OUTPUT_DIR / "test_plot_vs_k_with_bold_theories.png",
     )
     assert fig is not None
 
@@ -119,6 +119,6 @@ def test_plot_vs_k_with_limit_and_theory_styling():
                 "shade_color": "C2",
             },
         },
-        out=OUTPUT_DIR / "test_plot_vs_k_with_limit_and_theory_styling.pdf",
+        out=OUTPUT_DIR / "test_plot_vs_k_with_limit_and_theory_styling.png",
     )
     assert fig is not None


### PR DESCRIPTION
- I implement the simplest fix to Cycylopt's issue with reading dicts and dict of dicts. Instead of populating the dicts with some terse '[keyword dot-notation](https://cyclopts.readthedocs.io/en/latest/rules.html#dict)', I use a converter function ```_json_str_to_dict()``` that takes in a string and converts that into a Python dict. This seems most natural to me honestly, and gets rid of any complex type coercions or style classes we can construct.
- I add CLI tests (`test_cli_plotting.py`) that mirror the plotting tests (`test_plotting.py`). As a bonus, I've added plot comparison as part of the CLI tests (making sure of the testing order in `conftest.py`)

## Summary by Sourcery

Improve CLI plotting usability and add robust CLI regression tests against library plotting output.

New Features:
- Allow CLI plotting style dictionaries to be passed as JSON strings and converted automatically.
- Add CLI plotting tests that invoke the plot-vs-k command and compare generated images to library-generated references.

Bug Fixes:
- Fix Cyclopts handling of dict and nested dict plotting style arguments by replacing ad-hoc coercion with explicit JSON conversion.

Enhancements:
- Adjust CLI app configuration to use markdown help formatting and show defaults for parameters, while hiding negative flags for None-typed params.
- Standardize plotting tests to write PNG outputs for image comparison with CLI tests.
- Ensure plotting tests run before CLI plotting tests via a pytest collection hook.

Documentation:
- Update README CLI examples to use JSON dictionaries for style options and the revised argument syntax.

Tests:
- Add image-based regression tests for the plot-vs-k CLI, mirroring existing plotting tests and validating visual consistency.