### PR TITLE
Review suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ We welcome contributions to this repository from the community. If you would lik
         z: [8.6]
     ```
 
-* If you would like to add unpublished data or simulations to a plot, please fork this repository and add the data or simulations in your fork. If the data or simulations are subsequently published we welcome a pull request from your fork to add them to this repository.
+* If you would like to plot or compare unpublished data, you can create a local YAML file and load it in the code using  `DataSet.load("/path/to/my_data.yaml")`.
 
 * If you would like to report a bug or request a feature, please file an issue on the github repository.
 

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -79,7 +79,7 @@
     "- `select_z_range(z_min, z_max)`: selects the redshift bins in the range $z_\\mathrm{min} \\leq z \\leq z_\\mathrm{max}$.\n",
     "- `select_k_range(k_min, k_max)`: selects the $k$-bins in the range $k_\\mathrm{min} \\leq k \\leq k_\\mathrm{max}$.\n",
     "- `select_delta_squared_range(delta_squared_min, delta_squared_max)`: selects the limits in the range $\\Delta_{21,\\mathrm{min}}^2 \\leq \\Delta_{21}^2 \\leq \\Delta_{21,\\mathrm{max}}^2$.\n",
-    "- `select_lowest_delta_squared(per_z=False, per_tag=False)`: selects the lowest limit in each redshift bin. If `per_z=True` is passed, it will pick the lowest for a given $z$-bin (across all $z$-tags, i.e. polarizations or fields). If `per_tag=True` is passed, it will pick the lowest for a given $z$-tag (across all $z$-bins).\n",
+    "- `select_lowest_delta_squared(per_z=True, per_tag=False)`: selects the lowest limits. `per_z` and `per_tag` are boolean flags that control how the lowest limits are selected (i.e. across redshift bins and/or across tags).\n",
     "\n",
     "Let's do some cuts on the data to select only the limits in the range $z=7-10$ and $k=0.1-1$ h/Mpc."
    ]

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -245,11 +245,6 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "eor_limits",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -79,7 +79,7 @@
     "- `select_z_range(z_min, z_max)`: selects the redshift bins in the range $z_\\mathrm{min} \\leq z \\leq z_\\mathrm{max}$.\n",
     "- `select_k_range(k_min, k_max)`: selects the $k$-bins in the range $k_\\mathrm{min} \\leq k \\leq k_\\mathrm{max}$.\n",
     "- `select_delta_squared_range(delta_squared_min, delta_squared_max)`: selects the limits in the range $\\Delta_{21,\\mathrm{min}}^2 \\leq \\Delta_{21}^2 \\leq \\Delta_{21,\\mathrm{max}}^2$.\n",
-    "- `select_lowest_delta_squared()`: selects the lowest limit in each redshift bin.\n",
+    "- `select_lowest_delta_squared()`: selects the lowest limit in each redshift bin. If `collapse_z_tags=True` is passed, it will pick the lowest for a given $z$-bin (across all $z$-tags, i.e. polarizations or fields).\n",
     "\n",
     "Let's do some cuts on the data to select only the limits in the range $z=7-10$ and $k=0.1-1$ h/Mpc."
    ]

--- a/docs/source/tutorial.ipynb
+++ b/docs/source/tutorial.ipynb
@@ -79,7 +79,7 @@
     "- `select_z_range(z_min, z_max)`: selects the redshift bins in the range $z_\\mathrm{min} \\leq z \\leq z_\\mathrm{max}$.\n",
     "- `select_k_range(k_min, k_max)`: selects the $k$-bins in the range $k_\\mathrm{min} \\leq k \\leq k_\\mathrm{max}$.\n",
     "- `select_delta_squared_range(delta_squared_min, delta_squared_max)`: selects the limits in the range $\\Delta_{21,\\mathrm{min}}^2 \\leq \\Delta_{21}^2 \\leq \\Delta_{21,\\mathrm{max}}^2$.\n",
-    "- `select_lowest_delta_squared()`: selects the lowest limit in each redshift bin. If `collapse_z_tags=True` is passed, it will pick the lowest for a given $z$-bin (across all $z$-tags, i.e. polarizations or fields).\n",
+    "- `select_lowest_delta_squared(per_z=False, per_tag=False)`: selects the lowest limit in each redshift bin. If `per_z=True` is passed, it will pick the lowest for a given $z$-bin (across all $z$-tags, i.e. polarizations or fields). If `per_tag=True` is passed, it will pick the lowest for a given $z$-tag (across all $z$-bins).\n",
     "\n",
     "Let's do some cuts on the data to select only the limits in the range $z=7-10$ and $k=0.1-1$ h/Mpc."
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,12 +50,13 @@ dev = [
     "ruff>=0.14.14",
 ]
 docs = [
-    "sphinx-book-theme>=1.1.4",
     "ipython>=9.9.0",
+    "jupyter>=1.1.1",
     "myst-parser>=5.0.0",
     "nbsphinx>=0.9.8",
     "numpydoc>=1.10.0",
     "sphinx>=9.1.0",
+    "sphinx-book-theme>=1.1.4",
 ]
 
 

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -373,8 +373,8 @@ class DataSet:
         field : str, optional
             The field to apply the mask to. Can be "z" (default) or "z_tags".
         """
-        fld = getattr(self.data, field)
-        fld_mask = np.array([mask(q) for q in fld] if field == "z_tags" else mask(fld))
+        fld = np.array(getattr(self.data, field))
+        fld_mask = mask(fld)
         if not fld_mask.any():
             raise ValueError("No data points found with this mask")
         if fld_mask.shape != self.data.z.shape:
@@ -613,16 +613,24 @@ class DataSet:
 
         return self._select_with_k_based_mask(mask, "k")
 
-    def select_lowest_delta_squared(self, collapse_z_tags: bool = False) -> Self:
+    def select_lowest_delta_squared(self,
+                                    per_z: bool = False,
+                                    per_tag: bool = False) -> Self:
         """
         Return a new DataSet with only the lowest |dsq| data points.
 
         Parameters
         ----------
-        collapse_z_tags : bool, optional
+        per_z : bool, optional
             If True, and the dataset has |z| tags (e.g. multiple fields or
             polarizations at the same redshift), collapse across tags by
             keeping only the field with the lowest |dsq|.
+            If False (default), maintains them as separate entries.
+
+        per_tag : bool, optional
+            If True, and the dataset has |z| tags (e.g. multiple fields or
+            polarizations at the same redshift), collapse across |z| by
+            keeping only the |z| with the lowest |dsq|.
             If False (default), maintains them as separate entries.
 
         Returns
@@ -637,20 +645,23 @@ class DataSet:
             m[np.nanargmin(dsq)] = True
             return m
 
+        def z_mask_gen(fld, dsq):
+            m = np.zeros(len(fld), dtype=bool)
+            for f in set(fld):
+                idx = [i for i, g in enumerate(fld) if g == f]
+                m[idx[np.nanargmin([dsq[i][0] for i in idx])]] = True
+            return m
+
         selected = self._select_with_k_based_mask(k_mask, "delta_squared")
 
-        if collapse_z_tags and self.data.z_tags is not None:
-            unique_zs = set(selected.data.z)
-            z_mask = np.zeros(len(selected.data.z), dtype=bool)
-            for z_val in unique_zs:
-                idx = [i for i, z in enumerate(selected.data.z) if z == z_val]
-                dsq_minima = [selected.data.delta_squared[i][0] for i in idx]
-                best = idx[np.nanargmin(dsq_minima)]
-                z_mask[best] = True
-            # The z_mask below is a bit of a hack; it's not a functional mask.
-            # It just forces the custom mask through.
-            selected = selected._select_with_z_based_mask(lambda z: z_mask, "z")
-
+        if self.data.z_tags is not None:
+            if per_z:
+                z_mask = z_mask_gen(selected.data.z, selected.data.delta_squared)
+                selected = selected._select_with_z_based_mask(lambda z: z_mask, "z")
+            if per_tag:
+                z_mask = z_mask_gen(selected.data.z_tags, selected.data.delta_squared)
+                selected = selected._select_with_z_based_mask(lambda t: z_mask,
+                                                              "z_tags")
         return selected
 
     @property

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -369,8 +369,12 @@ class DataSet:
             raise ValueError("Mask must have the same shape as z.")
         new_data = Data(
             z=self.data.z[fld_mask],
-            z_lower=self.data.z_lower[fld_mask] if self.data.z_lower is not None else None,
-            z_upper=self.data.z_upper[fld_mask] if self.data.z_upper is not None else None,
+            z_lower=self.data.z_lower[fld_mask]
+            if self.data.z_lower is not None
+            else None,
+            z_upper=self.data.z_upper[fld_mask]
+            if self.data.z_upper is not None
+            else None,
             z_tags=tuple(
                 self.data.z_tags[i] for i in range(len(self.data.z)) if fld_mask[i]
             )
@@ -388,7 +392,9 @@ class DataSet:
             if self.data.k_upper is not None
             else None,
             delta_squared=tuple(
-                self.data.delta_squared[i] for i in range(len(self.data.z)) if fld_mask[i]
+                self.data.delta_squared[i]
+                for i in range(len(self.data.z))
+                if fld_mask[i]
             ),
         )
         return attrs.evolve(self, data=new_data)
@@ -466,8 +472,8 @@ class DataSet:
 
         def mask(z):
             return (z >= z_min) & (z <= z_max)
-        
-        try: 
+
+        try:
             return self._select_with_z_based_mask(mask, "z")
         except ValueError as err:
             raise ValueError(
@@ -549,15 +555,14 @@ class DataSet:
             to ``z_target``.
 
         """
-        
+
         def mask(z):
             # Note: this mask is different from select_closest_k because
-            # some datasets have multiple entries for the same redshift 
+            # some datasets have multiple entries for the same redshift
             # (e.g. different polarizations or fields), so we want to keep all of them.
             closest = z[np.argmin(np.abs(z - z_target))]
-            mask = (z == closest)
-            return mask
-        
+            return (z == closest)
+
         return self._select_with_z_based_mask(mask, "z")
 
     def select_closest_k(self, k_target: float) -> Self:

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -561,7 +561,7 @@ class DataSet:
             # some datasets have multiple entries for the same redshift
             # (e.g. different polarizations or fields), so we want to keep all of them.
             closest = z[np.argmin(np.abs(z - z_target))]
-            return (z == closest)
+            return z == closest
 
         return self._select_with_z_based_mask(mask, "z")
 
@@ -607,6 +607,7 @@ class DataSet:
             A new DataSet containing only the data point with the lowest |dsq|
             value for each redshift.
         """
+
         def k_mask(dsq):
             m = np.zeros_like(dsq, dtype=bool)
             m[np.nanargmin(dsq)] = True

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -584,9 +584,17 @@ class DataSet:
 
         return self._select_with_k_based_mask(mask, "k")
 
-    def select_lowest_delta_squared(self) -> Self:
+    def select_lowest_delta_squared(self, collapse_z_tags=False) -> Self:
         """
         Return a new DataSet with only the lowest |dsq| data points.
+
+        Parameters
+        ----------
+        collapse_z_tags : bool, optional
+            If True, and the dataset has |z| tags (e.g. multiple fields or
+            polarizations at the same redshift), collapse across tags by
+            keeping only the field with the lowest |dsq|.
+            If False (default), maintains them as separate entries.
 
         Returns
         -------
@@ -594,14 +602,26 @@ class DataSet:
             A new DataSet containing only the data point with the lowest |dsq|
             value for each redshift.
         """
+        def k_mask(dsq):
+            m = np.zeros_like(dsq, dtype=bool)
+            m[np.nanargmin(dsq)] = True
+            return m
 
-        def mask(dsq):
-            idx = np.nanargmin(dsq)
-            mask = np.zeros_like(dsq, dtype=bool)
-            mask[idx] = True
-            return mask
+        selected = self._select_with_k_based_mask(k_mask, "delta_squared")
 
-        return self._select_with_k_based_mask(mask, "delta_squared")
+        if collapse_z_tags and self.data.z_tags is not None:
+            unique_zs = set(selected.data.z)
+            z_mask = np.zeros(len(selected.data.z), dtype=bool)
+            for z_val in unique_zs:
+                idx = [i for i, z in enumerate(selected.data.z) if z == z_val]
+                dsq_minima = [selected.data.delta_squared[i][0] for i in idx]
+                best = idx[np.nanargmin(dsq_minima)]
+                z_mask[best] = True
+            # The z_mask below is a bit of a hack; it's not a functional mask.
+            # It just forces the custom mask through.
+            selected = selected._select_with_z_based_mask(lambda z: z_mask, "z")
+
+        return selected
 
     @property
     def key(self) -> str:

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -613,9 +613,9 @@ class DataSet:
 
         return self._select_with_k_based_mask(mask, "k")
 
-    def select_lowest_delta_squared(self,
-                                    per_z: bool = False,
-                                    per_tag: bool = False) -> Self:
+    def select_lowest_delta_squared(
+        self, per_z: bool = False, per_tag: bool = False
+    ) -> Self:
         """
         Return a new DataSet with only the lowest |dsq| data points.
 
@@ -660,8 +660,9 @@ class DataSet:
                 selected = selected._select_with_z_based_mask(lambda z: z_mask, "z")
             if per_tag:
                 z_mask = z_mask_gen(selected.data.z_tags, selected.data.delta_squared)
-                selected = selected._select_with_z_based_mask(lambda t: z_mask,
-                                                              "z_tags")
+                selected = selected._select_with_z_based_mask(
+                    lambda t: z_mask, "z_tags"
+                )
         return selected
 
     @property

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -360,33 +360,35 @@ class DataSet:
 
         return converter.structure(yaml_data, cls)
 
-    def _select_with_z_based_mask(self, mask: np.ndarray) -> Self:
-        if not mask.any():
+    def _select_with_z_based_mask(self, mask: callable, field: str = "z") -> Self:
+        fld = getattr(self.data, field)
+        fld_mask = np.array([mask(q) for q in fld] if field == "z_tags" else mask(fld))
+        if not fld_mask.any():
             raise ValueError("No data points found with this mask")
-        if mask.shape != self.data.z.shape:
+        if fld_mask.shape != self.data.z.shape:
             raise ValueError("Mask must have the same shape as z.")
         new_data = Data(
-            z=self.data.z[mask],
-            z_lower=self.data.z_lower[mask] if self.data.z_lower is not None else None,
-            z_upper=self.data.z_upper[mask] if self.data.z_upper is not None else None,
+            z=self.data.z[fld_mask],
+            z_lower=self.data.z_lower[fld_mask] if self.data.z_lower is not None else None,
+            z_upper=self.data.z_upper[fld_mask] if self.data.z_upper is not None else None,
             z_tags=tuple(
-                self.data.z_tags[i] for i in range(len(self.data.z)) if mask[i]
+                self.data.z_tags[i] for i in range(len(self.data.z)) if fld_mask[i]
             )
             if self.data.z_tags is not None
             else None,
-            k=tuple(self.data.k[i] for i in range(len(self.data.z)) if mask[i]),
+            k=tuple(self.data.k[i] for i in range(len(self.data.z)) if fld_mask[i]),
             k_lower=tuple(
-                self.data.k_lower[i] for i in range(len(self.data.z)) if mask[i]
+                self.data.k_lower[i] for i in range(len(self.data.z)) if fld_mask[i]
             )
             if self.data.k_lower is not None
             else None,
             k_upper=tuple(
-                self.data.k_upper[i] for i in range(len(self.data.z)) if mask[i]
+                self.data.k_upper[i] for i in range(len(self.data.z)) if fld_mask[i]
             )
             if self.data.k_upper is not None
             else None,
             delta_squared=tuple(
-                self.data.delta_squared[i] for i in range(len(self.data.z)) if mask[i]
+                self.data.delta_squared[i] for i in range(len(self.data.z)) if fld_mask[i]
             ),
         )
         return attrs.evolve(self, data=new_data)
@@ -461,12 +463,16 @@ class DataSet:
             A new DataSet containing only the data points with |z| values
             between ``z_min`` and ``z_max``.
         """
-        mask = (self.data.z >= z_min) & (self.data.z <= z_max)
-        if not mask.any():
+
+        def mask(z):
+            return (z >= z_min) & (z <= z_max)
+        
+        try: 
+            return self._select_with_z_based_mask(mask, "z")
+        except ValueError as err:
             raise ValueError(
-                f"No data points found in the redshift range {z_min} to {z_max}."
-            )
-        return self._select_with_z_based_mask(mask)
+                f"No data points found in the z range {z_min} to {z_max}."
+            ) from err
 
     def select_k_range(self, k_min: float, k_max: float) -> Self:
         """
@@ -543,10 +549,16 @@ class DataSet:
             to ``z_target``.
 
         """
-        idx = np.abs(self.data.z - z_target).argmin()
-        mask = np.zeros_like(self.data.z, dtype=bool)
-        mask[idx] = True
-        return self._select_with_z_based_mask(mask)
+        
+        def mask(z):
+            # Note: this mask is different from select_closest_k because
+            # some datasets have multiple entries for the same redshift 
+            # (e.g. different polarizations or fields), so we want to keep all of them.
+            closest = z[np.argmin(np.abs(z - z_target))]
+            mask = (z == closest)
+            return mask
+        
+        return self._select_with_z_based_mask(mask, "z")
 
     def select_closest_k(self, k_target: float) -> Self:
         """

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -613,25 +613,25 @@ class DataSet:
 
         return self._select_with_k_based_mask(mask, "k")
 
-    def select_lowest_delta_squared(
-        self, per_z: bool = False, per_tag: bool = False
-    ) -> Self:
+    def select_lowest_delta_squared(self,
+                                    per_z: bool = True,
+                                    per_tag: bool = False) -> Self:
         """
         Return a new DataSet with only the lowest |dsq| data points.
 
         Parameters
         ----------
         per_z : bool, optional
-            If True, and the dataset has |z| tags (e.g. multiple fields or
-            polarizations at the same redshift), collapse across tags by
-            keeping only the field with the lowest |dsq|.
-            If False (default), maintains them as separate entries.
+            If True (default), the lowest |dsq| is returned for each
+            redshift |z|. If False, the lowest |dsq| is returned across all
+            redshifts (i.e. the absolute lowest in case `per_tag` is also False;
+            otherwise, the lowest per |z| tag is returned).
 
         per_tag : bool, optional
             If True, and the dataset has |z| tags (e.g. multiple fields or
-            polarizations at the same redshift), collapse across |z| by
-            keeping only the |z| with the lowest |dsq|.
-            If False (default), maintains them as separate entries.
+            polarizations at the same redshift), they are treated as separate entries
+            and retained in the output If False (default), the lowest |dsq| is returned
+            across all |z| tags.
 
         Returns
         -------
@@ -645,24 +645,39 @@ class DataSet:
             m[np.nanargmin(dsq)] = True
             return m
 
-        def z_mask_gen(fld, dsq):
+        def z_mask_gen(data, field):
+            fld = np.array(getattr(data, field))
+            dsq = np.array(data.delta_squared)
             m = np.zeros(len(fld), dtype=bool)
             for f in set(fld):
                 idx = [i for i, g in enumerate(fld) if g == f]
                 m[idx[np.nanargmin([dsq[i][0] for i in idx])]] = True
             return m
 
+        # First collapse along the k-axis to find the lowest delta_squared value
+        # for each redshift entry.
         selected = self._select_with_k_based_mask(k_mask, "delta_squared")
 
-        if self.data.z_tags is not None:
-            if per_z:
-                z_mask = z_mask_gen(selected.data.z, selected.data.delta_squared)
+        if not per_z:
+            # Next, collapse along the z-axis depending on the per_tag flag.
+            if not per_tag or selected.data.z_tags is None:
+                # The absolute lowest delta_squared value across all z and z_tags
+                z_mask = np.zeros(len(selected.data.z), dtype=bool)
+                min_idx = np.nanargmin([dsq[0] for dsq in selected.data.delta_squared])
+                z_mask[min_idx] = True
                 selected = selected._select_with_z_based_mask(lambda z: z_mask, "z")
-            if per_tag:
-                z_mask = z_mask_gen(selected.data.z_tags, selected.data.delta_squared)
-                selected = selected._select_with_z_based_mask(
-                    lambda t: z_mask, "z_tags"
-                )
+            if per_tag and selected.data.z_tags is not None:
+                # If for some reason, the user wants only lowest per z_tag, but
+                # not per z. Bit of an edge case, but we can still handle it.
+                z_mask = z_mask_gen(selected.data, "z_tags")
+                selected = selected._select_with_z_based_mask(lambda z: z_mask, "z")
+        else:
+            if not per_tag and selected.data.z_tags is not None:
+                # If the user wants lowest per z, but not per z_tag, we need to collapse
+                # across z_tag.
+                z_mask = z_mask_gen(selected.data, "z")
+                selected = selected._select_with_z_based_mask(lambda z: z_mask, "z")
+
         return selected
 
     @property

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -613,9 +613,9 @@ class DataSet:
 
         return self._select_with_k_based_mask(mask, "k")
 
-    def select_lowest_delta_squared(self,
-                                    per_z: bool = True,
-                                    per_tag: bool = False) -> Self:
+    def select_lowest_delta_squared(
+        self, per_z: bool = True, per_tag: bool = False
+    ) -> Self:
         """
         Return a new DataSet with only the lowest |dsq| data points.
 

--- a/src/eor_limits/_datatypes.py
+++ b/src/eor_limits/_datatypes.py
@@ -361,6 +361,18 @@ class DataSet:
         return converter.structure(yaml_data, cls)
 
     def _select_with_z_based_mask(self, mask: callable, field: str = "z") -> Self:
+        """
+        Return a new DataSet with only the data points that satisfy the given z-mask.
+
+        Parameters
+        ----------
+        mask : callable
+            A callable that takes a single argument (the field value) and returns
+            a boolean indicating whether to keep that data point.
+            e.g. ``lambda z: (z >= z_min) & (z <= z_max)``.
+        field : str, optional
+            The field to apply the mask to. Can be "z" (default) or "z_tags".
+        """
         fld = getattr(self.data, field)
         fld_mask = np.array([mask(q) for q in fld] if field == "z_tags" else mask(fld))
         if not fld_mask.any():
@@ -400,6 +412,18 @@ class DataSet:
         return attrs.evolve(self, data=new_data)
 
     def _select_with_k_based_mask(self, mask: callable, field: str = "k") -> Self:
+        """
+        Return a new DataSet with only the data points that satisfy the given k-mask.
+
+        Parameters
+        ----------
+        mask : callable
+            A callable that takes a single argument (the field value) and returns
+            a boolean array indicating which data points to keep.
+            e.g. ``lambda k: (k >= k_min) & (k <= k_max)``.
+        field : str, optional
+            The field to apply the mask to. Can be "k" (default) or "delta_squared".
+        """
         fld = getattr(self.data, field)
         fld_mask = [mask(q) for q in fld]
         new_data = Data(
@@ -589,7 +613,7 @@ class DataSet:
 
         return self._select_with_k_based_mask(mask, "k")
 
-    def select_lowest_delta_squared(self, collapse_z_tags=False) -> Self:
+    def select_lowest_delta_squared(self, collapse_z_tags: bool = False) -> Self:
         """
         Return a new DataSet with only the lowest |dsq| data points.
 

--- a/src/eor_limits/_plot.py
+++ b/src/eor_limits/_plot.py
@@ -213,7 +213,8 @@ def plot_vs_k(
         limits = [load_limit_data(limit).drop_nan() for limit in limits]
         limits.sort(key=lambda limit: limit.year)
     else:
-        limits = [load_limit_data(limit).drop_nan() for limit in limits]
+        # DataSet.load() instead of load_limit_data() to allow loading from a YAML file.
+        limits = [DataSet.load(limit).drop_nan() for limit in limits]
 
     # Select the specified k and z ranges from the limits
     def _get_z_range_from_limits(limits):

--- a/src/eor_limits/_plot.py
+++ b/src/eor_limits/_plot.py
@@ -55,6 +55,7 @@ def plot_vs_z(*args, **kwargs):
 def plot_vs_k(
     # Limit plotting options
     limits: StrList = None,
+    *,
     base_limit_style: JsonDict = None,
     limit_styles: JsonNestedDict = None,
     bold_limits: StrList = None,
@@ -266,7 +267,7 @@ def plot_vs_k(
     # Whether to bold each limit in the legend
     bold_limits = bold_limits or []
     limit_labels = [
-        get_latex_limit_label(limit, bold=(limit.key in bold_limits))
+        get_latex_label(limit, bold=(limit.key in bold_limits))
         for limit in limits
     ]
 
@@ -309,7 +310,7 @@ def plot_vs_k(
     # Whether to bold each theory in the legend
     bold_theories = bold_theories or []
     theory_labels = [
-        get_latex_theory_label(theory, bold=(theory.key in bold_theories))
+        get_latex_label(theory, bold=(theory.key in bold_theories), theory=True)
         for theory in theories
     ]
 
@@ -488,6 +489,10 @@ def build_limit_styles(
         # Empty
         style = {}
         # Determine whether to plot as points or lines
+        if limit.key in aspoints and limit.key in aslines:
+            raise ValueError(
+                f"Limit {limit.key} specified in both aspoints and aslines."
+            )
         style["as_line"] = (
             False
             if limit.key in aspoints
@@ -563,31 +568,18 @@ def build_sensitivity_styles(
     return styles
 
 
-def get_latex_limit_label(paper: DataSet, bold: bool = False) -> str:
+def get_latex_label(paper: DataSet, bold: bool = False, theory: bool = False) -> str:
     """Get a LaTeX label for a limit paper."""
-    label_start = " $\\bf{" if bold else " $\\rm{"
+    if theory:
+        label_start = " $\\bf{Theory:} \\bf{" if bold else " $\\bf{Theory:} \\rm{"
+    else:
+        label_start = " $\\bf{" if bold else " $\\rm{"
     label_end = "}$"
     return (
         label_start
         + r"\ ".join(paper.telescope.split(" "))
         + r"\ ("
         + paper.author
-        + r",\ "
-        + str(paper.year)
-        + ")"
-        + label_end
-    )
-
-
-def get_latex_theory_label(paper: DataSet, bold: bool = False) -> str:
-    """Get a LaTeX label for a theory paper."""
-    label_start = " $\\bf{Theory:} \\bf{" if bold else " $\\bf{Theory:} \\rm{"
-    label_end = "}$"
-    return (
-        label_start
-        + r"\ ".join(paper.telescope.split(" "))
-        + r"\ ("
-        + r"\ ".join(paper.author.split(" "))
         + r",\ "
         + str(paper.year)
         + ")"

--- a/src/eor_limits/_plot.py
+++ b/src/eor_limits/_plot.py
@@ -53,7 +53,6 @@ def plot_vs_z(*args, **kwargs):
 
 
 def plot_vs_k(
-    *,
     # Limit plotting options
     limits: StrList = None,
     *,

--- a/src/eor_limits/_plot.py
+++ b/src/eor_limits/_plot.py
@@ -268,8 +268,7 @@ def plot_vs_k(
     # Whether to bold each limit in the legend
     bold_limits = bold_limits or []
     limit_labels = [
-        get_latex_label(limit, bold=(limit.key in bold_limits))
-        for limit in limits
+        get_latex_label(limit, bold=(limit.key in bold_limits)) for limit in limits
     ]
 
     # Plotting the limits as points or lines, depending on the number of k values

--- a/src/eor_limits/data/Beardsley2016.yaml
+++ b/src/eor_limits/data/Beardsley2016.yaml
@@ -1,9 +1,9 @@
 telescope: MWA
 author: Beardsley
-year: 2019
+year: 2016
 doi: 10.3847/1538-4357/833/1/102
 notes:
-    - The k_lower and k_upper values are not in the paper, they came via private communication from N. Barry, who got the files from A. Beardsley (see data files for the k edges).
+    - The k_lower and k_upper values are not in the paper, they came via private communication from N. Barry, who got the files from A. Beardsley.
 
 data:
     delta_squared: [[3.67e+4], [2.70e+4], [3.56e+4], [3.02e+4], [4.70e+4], [3.22e+4]] #, [3.2e4], [2.6e4], [2.5e4]] these last values are not in the original paper

--- a/src/eor_limits/data/HERA2023.yaml
+++ b/src/eor_limits/data/HERA2023.yaml
@@ -51,5 +51,5 @@ data:
     z: [10.37, 10.37, 10.37, 10.37, 10.37, 7.93, 7.93, 7.93, 7.93, 7.93]
     z_lower:
     z_upper:
-    z_tags: ['Band 1 Field A', 'Band 1 Field B', 'Band 1 Field C', 'Band 1 Field D', 'Band 1 Field E',
-            'Band 2 Field A', 'Band 2 Field B', 'Band 2 Field C', 'Band 2 Field D', 'Band 2 Field E']
+    z_tags: ['Field A', 'Field B', 'Field C', 'Field D', 'Field E',
+            'Field A', 'Field B', 'Field C', 'Field D', 'Field E']

--- a/src/eor_limits/data/Kolopanis2019.yaml
+++ b/src/eor_limits/data/Kolopanis2019.yaml
@@ -3,7 +3,7 @@ author: Kolopanis
 year: 2019
 doi: 10.3847/1538-4357/ab3e3a
 notes:
-    - The k_lower and k_upper values are not in the paper, they came via private communication from  M. Kolopanis, assuming linear binning from the k values he provided (see data files for the k edges).
+    - The k_lower and k_upper values are not in the paper, they came via private communication from  M. Kolopanis, assuming linear binning from the k values he provided.
 
 data:
     delta_squared: [[8.09e4], [1.28e5], [3.61e4], [1.46e5], [3.8e6], [2.41e6]]

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -89,3 +89,17 @@ def test_select_lowest_delta_squared():
     for original_arr, selected_arr in zip(dataset.data.delta_squared, selected.data.delta_squared):
         assert len(selected_arr) == 1
         assert selected_arr[0] == np.nanmin(original_arr)
+
+
+def test_select_lowest_delta_squared_collapse_z_tags():
+    """Test selecting the lowest delta_squared value from a dataset with collapse_z_tags=True."""
+    dataset = DataSet.load("HERA2023") # known to have multiple z tags
+    selected = dataset.select_lowest_delta_squared(collapse_z_tags=True)
+    assert isinstance(selected, DataSet)
+    unique_zs = set(dataset.data.z)
+    assert len(selected.data.z) == len(unique_zs)
+    for z_val in unique_zs:
+        idx = [i for i, z in enumerate(dataset.data.z) if z == z_val]
+        best_dsq = np.nanmin([np.nanmin(dataset.data.delta_squared[i]) for i in idx])
+        selected_dsq = selected.data.delta_squared[list(selected.data.z).index(z_val)][0]
+        assert selected_dsq == best_dsq

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -84,45 +84,53 @@ def test_select_closest_k():
     assert selected.data.k[0][0] == k_val
 
 
-def test_select_lowest_delta_squared():
-    """Test selecting the lowest delta_squared value from a dataset."""
-    dataset = DataSet.load("HERA2026")
+def test_select_lowest_delta_squared_per_z():
+    """Test selecting the lowest delta_squared value per z (default behaviour)."""
+    dataset = DataSet.load("HERA2023")
     selected = dataset.select_lowest_delta_squared()
     assert isinstance(selected, DataSet)
-    for original_dsq, selected_dsq in zip(
-        dataset.data.delta_squared, selected.data.delta_squared, strict=True
-    ):
-        assert len(selected_dsq) == 1
-        assert selected_dsq[0] == np.nanmin(original_dsq)
-
-
-def test_select_lowest_delta_squared_per_z():
-    """Test selecting the lowest delta_squared value with per_z=True."""
-    dataset = DataSet.load("HERA2023")  # known to have multiple z tags
-    selected = dataset.select_lowest_delta_squared(per_z=True)
-    assert isinstance(selected, DataSet)
-    unique_zs = set(dataset.data.z)
-    assert len(selected.data.z) == len(unique_zs)
-    for z_val in unique_zs:
+    assert len(selected.data.z) == len(set(dataset.data.z))
+    for z_val in set(dataset.data.z):
         idx = [i for i, z in enumerate(dataset.data.z) if z == z_val]
-        all_best_dsq = [np.nanmin(dataset.data.delta_squared[i]) for i in idx]
-        best_dsq = np.nanmin(all_best_dsq)
+        best_dsq = np.nanmin([np.nanmin(dataset.data.delta_squared[i]) for i in idx])
         selected_idx = list(selected.data.z).index(z_val)
         selected_dsq = selected.data.delta_squared[selected_idx][0]
         assert selected_dsq == best_dsq
 
 
-def test_select_lowest_delta_squared_per_tag():
-    """Test selecting the lowest delta_squared value with per_tag=True."""
-    dataset = DataSet.load("HERA2023")  # known to have multiple z tags
-    selected = dataset.select_lowest_delta_squared(per_tag=True)
+def test_select_lowest_delta_squared_per_z_per_tag():
+    """Test selecting the lowest delta_squared value per z and per tag."""
+    dataset = DataSet.load("HERA2023")
+    selected = dataset.select_lowest_delta_squared(per_z=True, per_tag=True)
     assert isinstance(selected, DataSet)
-    unique_tags = set(dataset.data.z_tags)
-    assert len(selected.data.z_tags) == len(unique_tags)
-    for tag_val in unique_tags:
-        idx = [i for i, t in enumerate(dataset.data.z_tags) if t == tag_val]
-        all_best_dsq = [np.nanmin(dataset.data.delta_squared[i]) for i in idx]
-        best_dsq = np.nanmin(all_best_dsq)
-        selected_idx = list(selected.data.z_tags).index(tag_val)
+    assert len(selected.data.z) == len(dataset.data.z)
+    for dataset_dsq, selected_dsq in zip(dataset.data.delta_squared,
+                                         selected.data.delta_squared,
+                                         strict=True):
+        assert len(selected_dsq) == 1
+        assert selected_dsq[0] == np.nanmin(dataset_dsq)
+
+
+def test_select_lowest_delta_squared_not_per_z_not_per_tag():
+    """Test selecting the single globally lowest delta_squared value."""
+    dataset = DataSet.load("HERA2023")
+    selected = dataset.select_lowest_delta_squared(per_z=False, per_tag=False)
+    assert isinstance(selected, DataSet)
+    assert len(selected.data.z) == 1
+    global_min = np.nanmin([np.nanmin(dsq) for dsq in dataset.data.delta_squared])
+    selected_dsq = selected.data.delta_squared[0][0]
+    assert selected_dsq == global_min
+
+
+def test_select_lowest_delta_squared_not_per_z_per_tag():
+    """Test selecting the lowest delta_squared value per tag across all z."""
+    dataset = DataSet.load("HERA2023")
+    selected = dataset.select_lowest_delta_squared(per_z=False, per_tag=True)
+    assert isinstance(selected, DataSet)
+    assert len(selected.data.z) == len(set(dataset.data.z_tags))
+    for tag in set(dataset.data.z_tags):
+        idx = [i for i, t in enumerate(dataset.data.z_tags) if t == tag]
+        best_dsq = np.nanmin([np.nanmin(dataset.data.delta_squared[i]) for i in idx])
+        selected_idx = list(selected.data.z_tags).index(tag)
         selected_dsq = selected.data.delta_squared[selected_idx][0]
         assert selected_dsq == best_dsq

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -61,7 +61,8 @@ def test_select_closest_z():
     """Test selecting the closest z value from a dataset."""
     dataset = DataSet.load("HERA2026")
     z_val = dataset.data.z[5]
-    z_neighbour = min(dataset.data.z[4], dataset.data.z[6], key=lambda z: abs(z - z_val))
+    z_neighbour = min(dataset.data.z[4], dataset.data.z[6],
+                      key=lambda z: abs(z - z_val))
     offset = (z_neighbour - z_val) / 4  # guaranteed closer to z_val than z_neighbour
     selected = dataset.select_closest_z(z_val + offset)
     assert isinstance(selected, DataSet)
@@ -73,7 +74,8 @@ def test_select_closest_k():
     """Test selecting the closest k value from a dataset."""
     dataset = DataSet.load("HERA2026")
     k_val = dataset.data.k[0][5]
-    k_neighbour = min(dataset.data.k[0][4], dataset.data.k[0][6], key=lambda k: abs(k - k_val))
+    k_neighbour = min(dataset.data.k[0][4], dataset.data.k[0][6],
+                      key=lambda k: abs(k - k_val))
     offset = (k_neighbour - k_val) / 4  # guaranteed closer to k_val than k_neighbour
     selected = dataset.select_closest_k(k_val + offset)
     assert isinstance(selected, DataSet)
@@ -86,20 +88,24 @@ def test_select_lowest_delta_squared():
     dataset = DataSet.load("HERA2026")
     selected = dataset.select_lowest_delta_squared()
     assert isinstance(selected, DataSet)
-    for original_arr, selected_arr in zip(dataset.data.delta_squared, selected.data.delta_squared):
-        assert len(selected_arr) == 1
-        assert selected_arr[0] == np.nanmin(original_arr)
+    for original_dsq, selected_dsq in zip(dataset.data.delta_squared,
+                                          selected.data.delta_squared,
+                                          strict=True):
+        assert len(selected_dsq) == 1
+        assert selected_dsq[0] == np.nanmin(original_dsq)
 
 
 def test_select_lowest_delta_squared_collapse_z_tags():
-    """Test selecting the lowest delta_squared value from a dataset with collapse_z_tags=True."""
-    dataset = DataSet.load("HERA2023") # known to have multiple z tags
+    """Test selecting the lowest delta_squared value with collapse_z_tags=True."""
+    dataset = DataSet.load("HERA2023")  # known to have multiple z tags
     selected = dataset.select_lowest_delta_squared(collapse_z_tags=True)
     assert isinstance(selected, DataSet)
     unique_zs = set(dataset.data.z)
     assert len(selected.data.z) == len(unique_zs)
     for z_val in unique_zs:
         idx = [i for i, z in enumerate(dataset.data.z) if z == z_val]
-        best_dsq = np.nanmin([np.nanmin(dataset.data.delta_squared[i]) for i in idx])
-        selected_dsq = selected.data.delta_squared[list(selected.data.z).index(z_val)][0]
+        all_best_dsq = [np.nanmin(dataset.data.delta_squared[i]) for i in idx]
+        best_dsq = np.nanmin(all_best_dsq)
+        selected_idx = list(selected.data.z).index(z_val)
+        selected_dsq = selected.data.delta_squared[selected_idx][0]
         assert selected_dsq == best_dsq

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -61,8 +61,9 @@ def test_select_closest_z():
     """Test selecting the closest z value from a dataset."""
     dataset = DataSet.load("HERA2026")
     z_val = dataset.data.z[5]
-    z_neighbour = min(dataset.data.z[4], dataset.data.z[6],
-                      key=lambda z: abs(z - z_val))
+    z_neighbour = min(
+        dataset.data.z[4], dataset.data.z[6], key=lambda z: abs(z - z_val)
+    )
     offset = (z_neighbour - z_val) / 4  # guaranteed closer to z_val than z_neighbour
     selected = dataset.select_closest_z(z_val + offset)
     assert isinstance(selected, DataSet)
@@ -74,8 +75,9 @@ def test_select_closest_k():
     """Test selecting the closest k value from a dataset."""
     dataset = DataSet.load("HERA2026")
     k_val = dataset.data.k[0][5]
-    k_neighbour = min(dataset.data.k[0][4], dataset.data.k[0][6],
-                      key=lambda k: abs(k - k_val))
+    k_neighbour = min(
+        dataset.data.k[0][4], dataset.data.k[0][6], key=lambda k: abs(k - k_val)
+    )
     offset = (k_neighbour - k_val) / 4  # guaranteed closer to k_val than k_neighbour
     selected = dataset.select_closest_k(k_val + offset)
     assert isinstance(selected, DataSet)
@@ -88,9 +90,9 @@ def test_select_lowest_delta_squared():
     dataset = DataSet.load("HERA2026")
     selected = dataset.select_lowest_delta_squared()
     assert isinstance(selected, DataSet)
-    for original_dsq, selected_dsq in zip(dataset.data.delta_squared,
-                                          selected.data.delta_squared,
-                                          strict=True):
+    for original_dsq, selected_dsq in zip(
+        dataset.data.delta_squared, selected.data.delta_squared, strict=True
+    ):
         assert len(selected_dsq) == 1
         assert selected_dsq[0] == np.nanmin(original_dsq)
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -51,7 +51,6 @@ def test_select_delta_squared_range():
     dsmax = ds_val * 10
     selected = dataset.select_delta_squared_range(dsmin, dsmax)
     assert isinstance(selected, DataSet)
-
     for ds_arr in selected.data.delta_squared:
         assert np.all(dsmin <= ds_arr)
         assert np.all(ds_arr <= dsmax)
@@ -97,10 +96,10 @@ def test_select_lowest_delta_squared():
         assert selected_dsq[0] == np.nanmin(original_dsq)
 
 
-def test_select_lowest_delta_squared_collapse_z_tags():
-    """Test selecting the lowest delta_squared value with collapse_z_tags=True."""
+def test_select_lowest_delta_squared_per_z():
+    """Test selecting the lowest delta_squared value with per_z=True."""
     dataset = DataSet.load("HERA2023")  # known to have multiple z tags
-    selected = dataset.select_lowest_delta_squared(collapse_z_tags=True)
+    selected = dataset.select_lowest_delta_squared(per_z=True)
     assert isinstance(selected, DataSet)
     unique_zs = set(dataset.data.z)
     assert len(selected.data.z) == len(unique_zs)
@@ -109,5 +108,21 @@ def test_select_lowest_delta_squared_collapse_z_tags():
         all_best_dsq = [np.nanmin(dataset.data.delta_squared[i]) for i in idx]
         best_dsq = np.nanmin(all_best_dsq)
         selected_idx = list(selected.data.z).index(z_val)
+        selected_dsq = selected.data.delta_squared[selected_idx][0]
+        assert selected_dsq == best_dsq
+
+
+def test_select_lowest_delta_squared_per_tag():
+    """Test selecting the lowest delta_squared value with per_tag=True."""
+    dataset = DataSet.load("HERA2023")  # known to have multiple z tags
+    selected = dataset.select_lowest_delta_squared(per_tag=True)
+    assert isinstance(selected, DataSet)
+    unique_tags = set(dataset.data.z_tags)
+    assert len(selected.data.z_tags) == len(unique_tags)
+    for tag_val in unique_tags:
+        idx = [i for i, t in enumerate(dataset.data.z_tags) if t == tag_val]
+        all_best_dsq = [np.nanmin(dataset.data.delta_squared[i]) for i in idx]
+        best_dsq = np.nanmin(all_best_dsq)
+        selected_idx = list(selected.data.z_tags).index(tag_val)
         selected_dsq = selected.data.delta_squared[selected_idx][0]
         assert selected_dsq == best_dsq

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -104,9 +104,9 @@ def test_select_lowest_delta_squared_per_z_per_tag():
     selected = dataset.select_lowest_delta_squared(per_z=True, per_tag=True)
     assert isinstance(selected, DataSet)
     assert len(selected.data.z) == len(dataset.data.z)
-    for dataset_dsq, selected_dsq in zip(dataset.data.delta_squared,
-                                         selected.data.delta_squared,
-                                         strict=True):
+    for dataset_dsq, selected_dsq in zip(
+        dataset.data.delta_squared, selected.data.delta_squared, strict=True
+    ):
         assert len(selected_dsq) == 1
         assert selected_dsq[0] == np.nanmin(dataset_dsq)
 

--- a/tests/test_datatypes.py
+++ b/tests/test_datatypes.py
@@ -61,7 +61,9 @@ def test_select_closest_z():
     """Test selecting the closest z value from a dataset."""
     dataset = DataSet.load("HERA2026")
     z_val = dataset.data.z[5]
-    selected = dataset.select_closest_z(z_val)
+    z_neighbour = min(dataset.data.z[4], dataset.data.z[6], key=lambda z: abs(z - z_val))
+    offset = (z_neighbour - z_val) / 4  # guaranteed closer to z_val than z_neighbour
+    selected = dataset.select_closest_z(z_val + offset)
     assert isinstance(selected, DataSet)
     assert len(selected.data.z) == 1
     assert selected.data.z[0] == z_val
@@ -71,7 +73,9 @@ def test_select_closest_k():
     """Test selecting the closest k value from a dataset."""
     dataset = DataSet.load("HERA2026")
     k_val = dataset.data.k[0][5]
-    selected = dataset.select_closest_k(k_val)
+    k_neighbour = min(dataset.data.k[0][4], dataset.data.k[0][6], key=lambda k: abs(k - k_val))
+    offset = (k_neighbour - k_val) / 4  # guaranteed closer to k_val than k_neighbour
+    selected = dataset.select_closest_k(k_val + offset)
     assert isinstance(selected, DataSet)
     assert len(selected.data.k[0]) == 1
     assert selected.data.k[0][0] == k_val
@@ -82,6 +86,6 @@ def test_select_lowest_delta_squared():
     dataset = DataSet.load("HERA2026")
     selected = dataset.select_lowest_delta_squared()
     assert isinstance(selected, DataSet)
-    for ds_arr in selected.data.delta_squared:
-        assert len(ds_arr) == 1
-        assert ds_arr[0] == np.nanmin(ds_arr)
+    for original_arr, selected_arr in zip(dataset.data.delta_squared, selected.data.delta_squared):
+        assert len(selected_arr) == 1
+        assert selected_arr[0] == np.nanmin(original_arr)

--- a/uv.lock
+++ b/uv.lock
@@ -32,12 +32,99 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.14.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/b5/001890774a9552aff22502b8da382593109ce0c95314abaebbb116567545/anyio-4.14.0.tar.gz", hash = "sha256:b47c1f9ccf73e67021df785332508f99379c68fa7d0684e8e3492cb1d4b23f89", size = 253586, upload-time = "2026-06-15T22:00:49.021Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/16/9826f089383c593cdfc4a6e5aca94d9e91ae1692c57af82c3b2aa5e810f7/anyio-4.14.0-py3-none-any.whl", hash = "sha256:dd9b7a2a9799ed6552fde617b2c5df02b7fdd7d88392fc48101e51bae46164d9", size = 123506, upload-time = "2026-06-15T22:00:47.595Z" },
+]
+
+[[package]]
+name = "appnope"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/35/5d/752690df9ef5b76e169e68d6a129fa6d08a7100ca7f754c89495db3c6019/appnope-0.1.4.tar.gz", hash = "sha256:1de3860566df9caf38f01f86f65e0e13e379af54f9e4bee1e66b48f2efffd1ee", size = 4170, upload-time = "2024-02-06T09:43:11.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/29/5ecc3a15d5a33e31b26c11426c45c501e439cb865d0bff96315d86443b78/appnope-0.1.4-py2.py3-none-any.whl", hash = "sha256:502575ee11cd7a28c0205f379b525beefebab9d161b7c964670864014ed7213c", size = 4321, upload-time = "2024-02-06T09:43:09.663Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
+]
+
+[[package]]
+name = "arrow"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "python-dateutil" },
+    { name = "tzdata" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/33/032cdc44182491aa708d06a68b62434140d8c50820a087fac7af37703357/arrow-1.4.0.tar.gz", hash = "sha256:ed0cc050e98001b8779e84d461b0098c4ac597e88704a655582b21d116e526d7", size = 152931, upload-time = "2025-10-18T17:46:46.761Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ed/c9/d7977eaacb9df673210491da99e6a247e93df98c715fc43fd136ce1d3d33/arrow-1.4.0-py3-none-any.whl", hash = "sha256:749f0769958ebdc79c173ff0b0670d59051a535fa26e8eba02953dc19eb43205", size = 68797, upload-time = "2025-10-18T17:46:45.663Z" },
+]
+
+[[package]]
 name = "asttokens"
 version = "3.0.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/be/a5/8e3f9b6771b0b408517c82d97aed8f2036509bc247d46114925e32fe33f0/asttokens-3.0.1.tar.gz", hash = "sha256:71a4ee5de0bde6a31d64f6b13f2293ac190344478f081c3d1bccfcf5eacb0cb7", size = 62308, upload-time = "2025-11-15T16:43:48.578Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/39/e7eaf1799466a4aef85b6a4fe7bd175ad2b1c6345066aa33f1f58d4b18d0/asttokens-3.0.1-py3-none-any.whl", hash = "sha256:15a3ebc0f43c2d0a50eeafea25e19046c68398e487b9f1f5b517f7c0f40f976a", size = 27047, upload-time = "2025-11-15T16:43:16.109Z" },
+]
+
+[[package]]
+name = "async-lru"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/1f/989ecfef8e64109a489fff357450cb73fa73a865a92bd8c272170a6922c2/async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6", size = 16332, upload-time = "2026-03-19T01:04:32.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/e2/c2e3abf398f80732e58b03be77bde9022550d221dd8781bf586bd4d97cc1/async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315", size = 8403, upload-time = "2026-03-19T01:04:30.883Z" },
 ]
 
 [[package]]
@@ -243,6 +330,15 @@ wheels = [
 ]
 
 [[package]]
+name = "comm"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/13/7d740c5849255756bc17888787313b61fd38a0a8304fc4f073dfc46122aa/comm-0.2.3.tar.gz", hash = "sha256:2dc8048c10962d55d7ad693be1e7045d891b7ce8d999c97963a5e3e99c055971", size = 6319, upload-time = "2025-07-25T14:02:04.452Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/891a0971e1e4a8c5d2b20bbe0e524dc04548d2307fee33cdeba148fd4fc7/comm-0.2.3-py3-none-any.whl", hash = "sha256:c615d91d75f7f04f095b30d1c1711babd43bdc6419c1be9886a85f2f4e489417", size = 7294, upload-time = "2025-07-25T14:02:02.896Z" },
+]
+
+[[package]]
 name = "contourpy"
 version = "1.3.3"
 source = { registry = "https://pypi.org/simple" }
@@ -407,6 +503,27 @@ wheels = [
 ]
 
 [[package]]
+name = "debugpy"
+version = "1.8.21"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/aa/12037145b7a56eaa5b29b41872f7a21b538e807e13f32c4d3c46e59be084/debugpy-1.8.21.tar.gz", hash = "sha256:a3c53278e84c94e11bd87c53970ec391d1a67396c8b22609fcac576520e611a6", size = 1697577, upload-time = "2026-06-01T19:30:35.156Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a2/df/bf625547431a9cadc9f4cbfeda38866e2b17f6aed147b625377e87834449/debugpy-1.8.21-cp312-cp312-macosx_15_0_universal2.whl", hash = "sha256:9f96713896f39c3dff0ee841f47320c3f2983d33c341e009361bb0ebc79adc4e", size = 2483609, upload-time = "2026-06-01T19:30:50.794Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/09/59324b903599031ff9faaec1758292409f6561a0ec2492fe4b703327705a/debugpy-1.8.21-cp312-cp312-manylinux_2_34_x86_64.whl", hash = "sha256:c193d474f0a211191f2b4449d2d06157c689013035bd952f3b617e0ef422b176", size = 3968900, upload-time = "2026-06-01T19:30:52.341Z" },
+    { url = "https://files.pythonhosted.org/packages/14/cd/27f65b805d7fe005c44e1a36b9183ecdfbcdbf9d3e721a5115d461ecc7ee/debugpy-1.8.21-cp312-cp312-win32.whl", hash = "sha256:4743373c1cac7f9e74a1b9915bf1dbe0e900eca657ffb170ae07ac8363205ae9", size = 5336340, upload-time = "2026-06-01T19:30:54.047Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1d/c84e30c0c674184948b66f076ab271c01d940618a2824c23cd035a27bc20/debugpy-1.8.21-cp312-cp312-win_amd64.whl", hash = "sha256:bd7ba9dd3daa7c2f942c6ca8d4695a16bf9ac16b63615261c7982bc74f7ed20c", size = 5374751, upload-time = "2026-06-01T19:30:55.891Z" },
+    { url = "https://files.pythonhosted.org/packages/77/6b/d817e1f8cc77aa055d37fba092e0febfdff40fe652d8d53d4cd7a86ad98d/debugpy-1.8.21-cp313-cp313-macosx_15_0_universal2.whl", hash = "sha256:13678151fc401e2d68c9880b91e28714f797d40422994572b24560ef80910a88", size = 2477398, upload-time = "2026-06-01T19:30:57.644Z" },
+    { url = "https://files.pythonhosted.org/packages/48/57/412421516afc3055fa577516f00beec3d663f9b0ab330639547ae6c57720/debugpy-1.8.21-cp313-cp313-manylinux_2_34_x86_64.whl", hash = "sha256:ecbd158386c31ffe71d46f72d44d56e66331ab9b16cad649156d514368f23ab2", size = 3962096, upload-time = "2026-06-01T19:30:59.235Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/62/2c616337cf6ba7b07ebbc97f02c6c945a8e2f76b365e33ee809c32ee36d1/debugpy-1.8.21-cp313-cp313-win32.whl", hash = "sha256:2c2ae706dec41d99a9ca1f7ebc987a83e65578363be6f6b3ac9067504917fae1", size = 5336288, upload-time = "2026-06-01T19:31:00.79Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/99/9175103392f84c4b1bf7622888cdc68da07f0ff7d9e581266428f6776033/debugpy-1.8.21-cp313-cp313-win_amd64.whl", hash = "sha256:aa648733047443eb1d07682c4ef287d36a54507b643ffdf38b09a3ef002c72a0", size = 5376567, upload-time = "2026-06-01T19:31:02.56Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3d/f4bbb323a548bfab2af3d6b4ffd9bf22636e55956a1285d317a1de643aad/debugpy-1.8.21-cp314-cp314-macosx_15_0_universal2.whl", hash = "sha256:9bb2a685287a2ac9b181cde89edcec64845cb51de7faaa75badb9a698bc24782", size = 2477209, upload-time = "2026-06-01T19:31:04.157Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/2d/6e7ec524984a1702777868de49a4c53202bddac2a432a76a093469587750/debugpy-1.8.21-cp314-cp314-manylinux_2_34_x86_64.whl", hash = "sha256:3d6922439bf33fd38a3e2c447869ebc7b97da5cd3d329ff1ef9bc06c4903437e", size = 3927115, upload-time = "2026-06-01T19:31:05.863Z" },
+    { url = "https://files.pythonhosted.org/packages/97/47/d1aa6d64005a98a9144647d99306b419396f9ad7bf1d73c119e17a81fb4d/debugpy-1.8.21-cp314-cp314-win32.whl", hash = "sha256:15d4963bd5ffa48f0da0947fd06757fa7621945048a14ad7705431566d3c0e7c", size = 5336724, upload-time = "2026-06-01T19:31:07.711Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/b905b90d163af11878c1af8abafa4a25206335e112e284e413454543a6da/debugpy-1.8.21-cp314-cp314-win_amd64.whl", hash = "sha256:fe0744a12353406de0ae8ccff0d0a4a666f00801a3db8fd04e7a5f761cd520e8", size = 5373803, upload-time = "2026-06-01T19:31:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/95/51/67e7cf11a53e40694f720457d5b3a1cdaaa3d5a9a633e482f225456b93ff/debugpy-1.8.21-py2.py3-none-any.whl", hash = "sha256:b1e37d333663c8851516a47364ef473da127f9caebe4417e6df6f5825a7e9a92", size = 5352888, upload-time = "2026-06-01T19:31:25.186Z" },
+]
+
+[[package]]
 name = "decorator"
 version = "5.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -475,6 +592,7 @@ dev = [
 ]
 docs = [
     { name = "ipython" },
+    { name = "jupyter" },
     { name = "myst-parser" },
     { name = "nbsphinx" },
     { name = "numpydoc" },
@@ -504,6 +622,7 @@ dev = [
 ]
 docs = [
     { name = "ipython", specifier = ">=9.9.0" },
+    { name = "jupyter", specifier = ">=1.1.1" },
     { name = "myst-parser", specifier = ">=5.0.0" },
     { name = "nbsphinx", specifier = ">=0.9.8" },
     { name = "numpydoc", specifier = ">=1.10.0" },
@@ -580,6 +699,24 @@ wheels = [
 ]
 
 [[package]]
+name = "fqdn"
+version = "1.5.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/3e/a80a8c077fd798951169626cde3e239adeba7dab75deb3555716415bd9b0/fqdn-1.5.1.tar.gz", hash = "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f", size = 6015, upload-time = "2021-03-11T07:16:29.08Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/58/8acf1b3e91c58313ce5cb67df61001fc9dcd21be4fadb76c1a2d540e09ed/fqdn-1.5.1-py3-none-any.whl", hash = "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014", size = 9121, upload-time = "2021-03-11T07:16:28.351Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "h5py"
 version = "3.15.1"
 source = { registry = "https://pypi.org/simple" }
@@ -612,6 +749,34 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/d3/39/a7ef948ddf4d1c556b0b2b9559534777bccc318543b3f5a1efdf6b556c9c/h5py-3.15.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:99d374a21f7321a4c6ab327c4ab23bd925ad69821aeb53a1e75dd809d19f67fa", size = 5025426, upload-time = "2025-10-16T10:35:19.831Z" },
     { url = "https://files.pythonhosted.org/packages/b6/d8/7368679b8df6925b8415f9dcc9ab1dab01ddc384d2b2c24aac9191bd9ceb/h5py-3.15.1-cp314-cp314-win_amd64.whl", hash = "sha256:9c73d1d7cdb97d5b17ae385153472ce118bed607e43be11e9a9deefaa54e0734", size = 2865704, upload-time = "2025-10-16T10:35:22.658Z" },
     { url = "https://files.pythonhosted.org/packages/d3/b7/4a806f85d62c20157e62e58e03b27513dc9c55499768530acc4f4c5ce4be/h5py-3.15.1-cp314-cp314-win_arm64.whl", hash = "sha256:a6d8c5a05a76aca9a494b4c53ce8a9c29023b7f64f625c6ce1841e92a362ccdf", size = 2465544, upload-time = "2025-10-16T10:35:25.695Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -651,6 +816,30 @@ wheels = [
 ]
 
 [[package]]
+name = "ipykernel"
+version = "7.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appnope", marker = "sys_platform == 'darwin'" },
+    { name = "comm" },
+    { name = "debugpy" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "matplotlib-inline" },
+    { name = "nest-asyncio2" },
+    { name = "packaging" },
+    { name = "psutil" },
+    { name = "pyzmq" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/c4/e4a38f579de4225a561305666f7541cdabb30075def2aa1ac17bd73c1fb5/ipykernel-7.3.0.tar.gz", hash = "sha256:9acaaaf97d16355166e4085afe9d225bfbdf2b7ef520f9df3be8f2b248275e09", size = 184899, upload-time = "2026-06-10T08:41:25.481Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/02/77b271f5dc58bfbc0b577c877b2365d1ffea2afe66a80c13f2312820348c/ipykernel-7.3.0-py3-none-any.whl", hash = "sha256:897eb64da762549ef610698fca5e9675195ec6ac8ec7f19d81ce1ca20c876057", size = 120583, upload-time = "2026-06-10T08:41:23.648Z" },
+]
+
+[[package]]
 name = "ipython"
 version = "9.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -684,6 +873,34 @@ wheels = [
 ]
 
 [[package]]
+name = "ipywidgets"
+version = "8.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "comm" },
+    { name = "ipython" },
+    { name = "jupyterlab-widgets" },
+    { name = "traitlets" },
+    { name = "widgetsnbextension" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4c/ae/c5ce1edc1afe042eadb445e95b0671b03cee61895264357956e61c0d2ac0/ipywidgets-8.1.8.tar.gz", hash = "sha256:61f969306b95f85fba6b6986b7fe45d73124d1d9e3023a8068710d47a22ea668", size = 116739, upload-time = "2025-11-01T21:18:12.393Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/56/6d/0d9848617b9f753b87f214f1c682592f7ca42de085f564352f10f0843026/ipywidgets-8.1.8-py3-none-any.whl", hash = "sha256:ecaca67aed704a338f88f67b1181b58f821ab5dc89c1f0f5ef99db43c1c2921e", size = 139808, upload-time = "2025-11-01T21:18:10.956Z" },
+]
+
+[[package]]
+name = "isoduration"
+version = "20.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "arrow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7c/1a/3c8edc664e06e6bd06cce40c6b22da5f1429aa4224d0c590f3be21c91ead/isoduration-20.11.0.tar.gz", hash = "sha256:ac2f9015137935279eac671f94f89eb00584f940f5dc49462a0c4ee692ba1bd9", size = 11649, upload-time = "2020-11-01T11:00:00.312Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/55/e5326141505c5d5e34c5e0935d2908a74e4561eca44108fbfb9c13d2911a/isoduration-20.11.0-py3-none-any.whl", hash = "sha256:b2904c2a4228c3d44f409c8ae8e2370eb21a26f7ac2ec5446df141dde3452042", size = 11321, upload-time = "2020-11-01T10:59:58.02Z" },
+]
+
+[[package]]
 name = "jedi"
 version = "0.19.2"
 source = { registry = "https://pypi.org/simple" }
@@ -708,6 +925,24 @@ wheels = [
 ]
 
 [[package]]
+name = "json5"
+version = "0.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e4/7d/05c46a96a78147ae3bf99c2f4169ce144a70220b8d6fcd56f6ec368b8ce9/json5-0.15.0.tar.gz", hash = "sha256:7424d1f1eb1d56da6e3d70643f53619862b4ce81440bdb8ecfd6f875e5ba4a71", size = 53278, upload-time = "2026-06-19T20:08:27.716Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/be/59527c99478aade6bb33a68d72e6e18dd4e6ff6eacfc7d01bdb15bc76912/json5-0.15.0-py3-none-any.whl", hash = "sha256:56636a30c0e8a4665fe2179c0212f32eae3796dea89ea6f649b9436ecdb39618", size = 36570, upload-time = "2026-06-19T20:08:26.748Z" },
+]
+
+[[package]]
+name = "jsonpointer"
+version = "3.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c7/af399a2e7a67fd18d63c40c5e62d3af4e67b836a2107468b6a5ea24c4304/jsonpointer-3.1.1.tar.gz", hash = "sha256:0b801c7db33a904024f6004d526dcc53bbb8a4a0f4e32bfd10beadf60adf1900", size = 9068, upload-time = "2026-03-23T22:32:32.458Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/6a/a83720e953b1682d2d109d3c2dbb0bc9bf28cc1cbc205be4ef4be5da709d/jsonpointer-3.1.1-py3-none-any.whl", hash = "sha256:8ff8b95779d071ba472cf5bc913028df06031797532f08a7d5b602d8b2a488ca", size = 7659, upload-time = "2026-03-23T22:32:31.568Z" },
+]
+
+[[package]]
 name = "jsonschema"
 version = "4.26.0"
 source = { registry = "https://pypi.org/simple" }
@@ -720,6 +955,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[package.optional-dependencies]
+format-nongpl = [
+    { name = "fqdn" },
+    { name = "idna" },
+    { name = "isoduration" },
+    { name = "jsonpointer" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "rfc3987-syntax" },
+    { name = "uri-template" },
+    { name = "webcolors" },
 ]
 
 [[package]]
@@ -735,8 +983,38 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter"
+version = "1.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipywidgets" },
+    { name = "jupyter-console" },
+    { name = "jupyterlab" },
+    { name = "nbconvert" },
+    { name = "notebook" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/58/f3/af28ea964ab8bc1e472dba2e82627d36d470c51f5cd38c37502eeffaa25e/jupyter-1.1.1.tar.gz", hash = "sha256:d55467bceabdea49d7e3624af7e33d59c37fff53ed3a350e1ac957bed731de7a", size = 5714959, upload-time = "2024-08-30T07:15:48.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/64/285f20a31679bf547b75602702f7800e74dbabae36ef324f716c02804753/jupyter-1.1.1-py2.py3-none-any.whl", hash = "sha256:7a59533c22af65439b24bbe60373a4e95af8f16ac65a6c00820ad378e3f7cc83", size = 2657, upload-time = "2024-08-30T07:15:47.045Z" },
+]
+
+[[package]]
+name = "jupyter-builder"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-core" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/fb/45/d0df8b43c10a61529c0f4a8af5e19ebe108f0c3af8f57e0fc358969907af/jupyter_builder-1.0.2.tar.gz", hash = "sha256:6155d78a5325010532a6419ffcba89eac643fd1aa56ea83115e661924d6f6aab", size = 968638, upload-time = "2026-06-12T02:33:25.767Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/28/b6/c418e0b3256f67c04933566b80bfce947350682db92c4b786a8653db32d6/jupyter_builder-1.0.2-py3-none-any.whl", hash = "sha256:b024f65d36e1d530542db597b00dd513261aa59842e0d0fbbb1015a9f1935e9c", size = 910789, upload-time = "2026-06-12T02:33:23.317Z" },
+]
+
+[[package]]
 name = "jupyter-client"
-version = "8.8.0"
+version = "8.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jupyter-core" },
@@ -744,10 +1022,30 @@ dependencies = [
     { name = "pyzmq" },
     { name = "tornado" },
     { name = "traitlets" },
+    { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/05/e4/ba649102a3bc3fbca54e7239fb924fd434c766f855693d86de0b1f2bec81/jupyter_client-8.8.0.tar.gz", hash = "sha256:d556811419a4f2d96c869af34e854e3f059b7cc2d6d01a9cd9c85c267691be3e", size = 348020, upload-time = "2026-01-08T13:55:47.938Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7d/dc/5512503b088997c2250b8bf18258fba9d9ce5ead641183700960d3c9d342/jupyter_client-8.9.1.tar.gz", hash = "sha256:a58f730dd9e728ba16ba1d62ebccf7ffe1ebbdbce4e95cfae941b7321ae1f4fa", size = 359256, upload-time = "2026-06-09T13:15:01.033Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2d/0b/ceb7694d864abc0a047649aec263878acb9f792e1fec3e676f22dc9015e3/jupyter_client-8.8.0-py3-none-any.whl", hash = "sha256:f93a5b99c5e23a507b773d3a1136bd6e16c67883ccdbd9a829b0bbdb98cd7d7a", size = 107371, upload-time = "2026-01-08T13:55:45.562Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/6f/56d39bf385c5c27988aebaf0c18a2a17e960575740100973511018bd904e/jupyter_client-8.9.1-py3-none-any.whl", hash = "sha256:0b7a295bc46e8751e9adae84781f726c851c1d911bd793edc4a3bde942e3da81", size = 109828, upload-time = "2026-06-09T13:14:58.835Z" },
+]
+
+[[package]]
+name = "jupyter-console"
+version = "6.6.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ipykernel" },
+    { name = "ipython" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "prompt-toolkit" },
+    { name = "pygments" },
+    { name = "pyzmq" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/bd/2d/e2fd31e2fc41c14e2bcb6c976ab732597e907523f6b2420305f9fc7fdbdb/jupyter_console-6.6.3.tar.gz", hash = "sha256:566a4bf31c87adbfadf22cdf846e3069b59a71ed5da71d6ba4d8aaad14a53539", size = 34363, upload-time = "2023-03-06T14:13:31.02Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/77/71d78d58f15c22db16328a476426f7ac4a60d3a5a7ba3b9627ee2f7903d4/jupyter_console-6.6.3-py3-none-any.whl", hash = "sha256:309d33409fcc92ffdad25f0bcdf9a4a9daa61b6f341177570fdac03de5352485", size = 24510, upload-time = "2023-03-06T14:13:28.229Z" },
 ]
 
 [[package]]
@@ -764,12 +1062,136 @@ wheels = [
 ]
 
 [[package]]
+name = "jupyter-events"
+version = "0.12.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jsonschema", extra = ["format-nongpl"] },
+    { name = "packaging" },
+    { name = "python-json-logger" },
+    { name = "pyyaml" },
+    { name = "referencing" },
+    { name = "rfc3339-validator" },
+    { name = "rfc3986-validator" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/f8/475c4241b2b75af0deaae453ed003c6c851766dbc44d332d8baf245dc931/jupyter_events-0.12.1.tar.gz", hash = "sha256:faff25f77218335752f35f23c5fe6e4a392a7bd99a5939ccb9b8fbf594636cf3", size = 62854, upload-time = "2026-04-20T23:17:50.66Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/eb/6c/6fcde0c8f616ed360ffd3587f7db9e225a7e62b583a04494d2f069cf64ea/jupyter_events-0.12.1-py3-none-any.whl", hash = "sha256:c366585253f537a627da52fa7ca7410c5b5301fe893f511e7b077c2d93ec8bcf", size = 19512, upload-time = "2026-04-20T23:17:48.927Z" },
+]
+
+[[package]]
+name = "jupyter-lsp"
+version = "2.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/36/ff/1e4a61f5170a9a1d978f3ac3872449de6c01fc71eaf89657824c878b1549/jupyter_lsp-2.3.1.tar.gz", hash = "sha256:fdf8a4aa7d85813976d6e29e95e6a2c8f752701f926f2715305249a3829805a6", size = 55677, upload-time = "2026-04-02T08:10:06.749Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/23/e8/9d61dcbd1dce8ef418f06befd4ac084b4720429c26b0b1222bc218685eff/jupyter_lsp-2.3.1-py3-none-any.whl", hash = "sha256:71b954d834e85ff3096400554f2eefaf7fe37053036f9a782b0f7c5e42dadb81", size = 77513, upload-time = "2026-04-02T08:10:01.753Z" },
+]
+
+[[package]]
+name = "jupyter-server"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "argon2-cffi" },
+    { name = "jinja2" },
+    { name = "jupyter-client" },
+    { name = "jupyter-core" },
+    { name = "jupyter-events" },
+    { name = "jupyter-server-terminals" },
+    { name = "nbconvert" },
+    { name = "nbformat" },
+    { name = "packaging" },
+    { name = "prometheus-client" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "pyzmq" },
+    { name = "send2trash" },
+    { name = "terminado" },
+    { name = "tornado" },
+    { name = "traitlets" },
+    { name = "websocket-client" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/6b/dc/db3a582633170186f8c8b31298d7eb26ad0eb031a1f53476c258b64eed05/jupyter_server-2.20.0.tar.gz", hash = "sha256:b5778ba337d8015a3dc2b80803ecdd5ac18d3797fddf61a50ea5fb472b4ebe14", size = 756523, upload-time = "2026-06-17T12:09:09.435Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/71/8c002223e873a870f5c41dc69b0a7c922301123e4a31d5d01ecb700aef77/jupyter_server-2.20.0-py3-none-any.whl", hash = "sha256:c3b67c93c471e947c18b5026f04f21614218adb706df8f48227d3ee8e0a7cdcc", size = 393143, upload-time = "2026-06-17T12:09:07.234Z" },
+]
+
+[[package]]
+name = "jupyter-server-terminals"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "terminado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a7/bcd0a9b0cbba88986fe944aaaf91bfda603e5a50bda8ed15123f381a3b2f/jupyter_server_terminals-0.5.4.tar.gz", hash = "sha256:bbda128ed41d0be9020349f9f1f2a4ab9952a73ed5f5ac9f1419794761fb87f5", size = 31770, upload-time = "2026-01-14T16:53:20.213Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/2d/6674563f71c6320841fc300911a55143925112a72a883e2ca71fba4c618d/jupyter_server_terminals-0.5.4-py3-none-any.whl", hash = "sha256:55be353fc74a80bc7f3b20e6be50a55a61cd525626f578dcb66a5708e2007d14", size = 13704, upload-time = "2026-01-14T16:53:18.738Z" },
+]
+
+[[package]]
+name = "jupyterlab"
+version = "4.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "async-lru" },
+    { name = "httpx" },
+    { name = "ipykernel" },
+    { name = "jinja2" },
+    { name = "jupyter-builder" },
+    { name = "jupyter-core" },
+    { name = "jupyter-lsp" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "packaging" },
+    { name = "tornado" },
+    { name = "traitlets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/3c/1ebd737b860cdbe61eed71536d06aab4e1781fbdcf07ecd5a1afe05b8adf/jupyterlab-4.6.0.tar.gz", hash = "sha256:6a8b88f2aae7ed4d012c634fc957c1a27f3aa217c32f0ced0175fac9ee17f9e5", size = 28181861, upload-time = "2026-06-18T13:52:56.039Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0a/eb/aa48075d0aa3d0188db34ba2704f53791757743c0bb02e18c4eef989b6de/jupyterlab-4.6.0-py3-none-any.whl", hash = "sha256:b6938cb8a1ef3d43860ff4745a680c62cc0a9385f9672295bb56cd2e7cfeebe2", size = 17143447, upload-time = "2026-06-18T13:52:51.42Z" },
+]
+
+[[package]]
 name = "jupyterlab-pygments"
 version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/90/51/9187be60d989df97f5f0aba133fa54e7300f17616e065d1ada7d7646b6d6/jupyterlab_pygments-0.3.0.tar.gz", hash = "sha256:721aca4d9029252b11cfa9d185e5b5af4d54772bb8072f9b7036f4170054d35d", size = 512900, upload-time = "2023-11-23T09:26:37.44Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b1/dd/ead9d8ea85bf202d90cc513b533f9c363121c7792674f78e0d8a854b63b4/jupyterlab_pygments-0.3.0-py3-none-any.whl", hash = "sha256:841a89020971da1d8693f1a99997aefc5dc424bb1b251fd6322462a1b8842780", size = 15884, upload-time = "2023-11-23T09:26:34.325Z" },
+]
+
+[[package]]
+name = "jupyterlab-server"
+version = "2.28.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "babel" },
+    { name = "jinja2" },
+    { name = "json5" },
+    { name = "jsonschema" },
+    { name = "jupyter-server" },
+    { name = "packaging" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d6/2c/90153f189e421e93c4bb4f9e3f59802a1f01abd2ac5cf40b152d7f735232/jupyterlab_server-2.28.0.tar.gz", hash = "sha256:35baa81898b15f93573e2deca50d11ac0ae407ebb688299d3a5213265033712c", size = 76996, upload-time = "2025-10-22T13:59:18.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/07/a000fe835f76b7e1143242ab1122e6362ef1c03f23f83a045c38859c2ae0/jupyterlab_server-2.28.0-py3-none-any.whl", hash = "sha256:e4355b148fdcf34d312bbbc80f22467d6d20460e8b8736bf235577dd18506968", size = 59830, upload-time = "2025-10-22T13:59:16.767Z" },
+]
+
+[[package]]
+name = "jupyterlab-widgets"
+version = "3.0.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/26/2d/ef58fed122b268c69c0aa099da20bc67657cdfb2e222688d5731bd5b971d/jupyterlab_widgets-3.0.16.tar.gz", hash = "sha256:423da05071d55cf27a9e602216d35a3a65a3e41cdf9c5d3b643b814ce38c19e0", size = 897423, upload-time = "2025-11-01T21:11:29.724Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/b5/36c712098e6191d1b4e349304ef73a8d06aed77e56ceaac8c0a306c7bda1/jupyterlab_widgets-3.0.16-py3-none-any.whl", hash = "sha256:45fa36d9c6422cf2559198e4db481aa243c7a32d9926b500781c830c80f7ecf8", size = 914926, upload-time = "2025-11-01T21:11:28.008Z" },
 ]
 
 [[package]]
@@ -842,6 +1264,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/99/dd/841e9a66c4715477ea0abc78da039832fbb09dac5c35c58dc4c41a407b8a/kiwisolver-1.4.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:aedff62918805fb62d43a4aa2ecd4482c380dc76cd31bd7c8878588a61bd0369", size = 2391835, upload-time = "2025-08-10T21:27:34.23Z" },
     { url = "https://files.pythonhosted.org/packages/0c/28/4b2e5c47a0da96896fdfdb006340ade064afa1e63675d01ea5ac222b6d52/kiwisolver-1.4.9-cp314-cp314t-win_amd64.whl", hash = "sha256:1fa333e8b2ce4d9660f2cda9c0e1b6bafcfb2457a9d259faa82289e73ec24891", size = 79988, upload-time = "2025-08-10T21:27:35.587Z" },
     { url = "https://files.pythonhosted.org/packages/80/be/3578e8afd18c88cdf9cb4cffde75a96d2be38c5a903f1ed0ceec061bd09e/kiwisolver-1.4.9-cp314-cp314t-win_arm64.whl", hash = "sha256:4a48a2ce79d65d363597ef7b567ce3d14d68783d2b2263d98db3d9477805ba32", size = 70260, upload-time = "2025-08-10T21:27:36.606Z" },
+]
+
+[[package]]
+name = "lark"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/34/28fff3ab31ccff1fd4f6c7c7b0ceb2b6968d8ea4950663eadcb5720591a0/lark-1.3.1.tar.gz", hash = "sha256:b426a7a6d6d53189d318f2b6236ab5d6429eaf09259f1ca33eb716eed10d2905", size = 382732, upload-time = "2025-10-27T18:25:56.653Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3d/14ce75ef66813643812f3093ab17e46d3a206942ce7376d31ec2d36229e7/lark-1.3.1-py3-none-any.whl", hash = "sha256:c629b661023a014c37da873b4ff58a817398d12635d3bbb2c5a03be7fe5d1e12", size = 113151, upload-time = "2025-10-27T18:25:54.882Z" },
 ]
 
 [[package]]
@@ -1105,12 +1536,50 @@ wheels = [
 ]
 
 [[package]]
+name = "nest-asyncio2"
+version = "1.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/73/731debf26e27e0a0323d7bda270dc2f634b398e38f040a09da1f4351d0aa/nest_asyncio2-1.7.2.tar.gz", hash = "sha256:1921d70b92cc4612c374928d081552efb59b83d91b2b789d935c665fa01729a8", size = 14743, upload-time = "2026-02-13T00:34:04.386Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/3c/3179b85b0e1c3659f0369940200cd6d0fa900e6cefcc7ea0bc6dd0e29ffb/nest_asyncio2-1.7.2-py3-none-any.whl", hash = "sha256:f5dfa702f3f81f6a03857e9a19e2ba578c0946a4ad417b4c50a24d7ba641fe01", size = 7843, upload-time = "2026-02-13T00:34:02.691Z" },
+]
+
+[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/24/bf/d1bda4f6168e0b2e9e5958945e01910052158313224ada5ce1fb2e1113b8/nodeenv-1.10.0.tar.gz", hash = "sha256:996c191ad80897d076bdfba80a41994c2b47c68e224c542b48feba42ba00f8bb", size = 55611, upload-time = "2025-12-20T14:08:54.006Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/88/b2/d0896bdcdc8d28a7fc5717c305f1a861c26e18c05047949fb371034d98bd/nodeenv-1.10.0-py2.py3-none-any.whl", hash = "sha256:5bb13e3eed2923615535339b3c620e76779af4cb4c6a90deccc9e36b274d3827", size = 23438, upload-time = "2025-12-20T14:08:52.782Z" },
+]
+
+[[package]]
+name = "notebook"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-builder" },
+    { name = "jupyter-server" },
+    { name = "jupyterlab" },
+    { name = "jupyterlab-server" },
+    { name = "notebook-shim" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/44/d5c65783f490298473bb1c05722e05ee2256231389559c2c5ae0a3e5d975/notebook-7.6.0.tar.gz", hash = "sha256:ea13e79e601bf273074895fdfb17dd3f2da916d3c045e0b9c47d18b16ab62481", size = 5497344, upload-time = "2026-06-18T16:18:55.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d1/e617c40db57ff40e75f43a7d4d1c305e3a54c053ab5cb0534a6c314664f9/notebook-7.6.0-py3-none-any.whl", hash = "sha256:98aa2811b54ac191321d5dfce12ca700f8a511a33a26e4de2fa106a357c43d6a", size = 5544575, upload-time = "2026-06-18T16:18:52.551Z" },
+]
+
+[[package]]
+name = "notebook-shim"
+version = "0.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jupyter-server" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/54/d2/92fa3243712b9a3e8bafaf60aac366da1cada3639ca767ff4b5b3654ec28/notebook_shim-0.2.4.tar.gz", hash = "sha256:b4b2cfa1b65d98307ca24361f5b30fe785b53c3fd07b7a47e89acb5e6ac638cb", size = 13167, upload-time = "2024-02-14T23:35:18.353Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f9/33/bd5b9137445ea4b680023eb0469b2bb969d61303dedb2aac6560ff3d14a1/notebook_shim-0.2.4-py3-none-any.whl", hash = "sha256:411a5be4e9dc882a074ccbcae671eda64cceb068767e9a3419096986560e1cef", size = 13307, upload-time = "2024-02-14T23:35:16.286Z" },
 ]
 
 [[package]]
@@ -1381,6 +1850,15 @@ wheels = [
 ]
 
 [[package]]
+name = "prometheus-client"
+version = "0.25.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/fb/d9aa83ffe43ce1f19e557c0971d04b90561b0cfd50762aafb01968285553/prometheus_client-0.25.0.tar.gz", hash = "sha256:5e373b75c31afb3c86f1a52fa1ad470c9aace18082d39ec0d2f918d11cc9ba28", size = 86035, upload-time = "2026-04-09T19:53:42.359Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8d/9b/d4b1e644385499c8346fa9b622a3f030dce14cd6ef8a1871c221a17a67e7/prometheus_client-0.25.0-py3-none-any.whl", hash = "sha256:d5aec89e349a6ec230805d0df882f3807f74fd6c1a2fa86864e3c2279059fed1", size = 64154, upload-time = "2026-04-09T19:53:41.324Z" },
+]
+
+[[package]]
 name = "prompt-toolkit"
 version = "3.0.52"
 source = { registry = "https://pypi.org/simple" }
@@ -1390,6 +1868,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]
@@ -1496,6 +2002,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
+name = "python-json-logger"
+version = "4.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "pywinpty"
+version = "3.0.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a9/ef/2d27f30c59a67be7025b2d7858c8c2d282b74d66544b2384730b82de74fd/pywinpty-3.0.5.tar.gz", hash = "sha256:61db0db063de9865adbea66db294628f8577f608d9764a4c7d3384eeacc4e81b", size = 16223484, upload-time = "2026-06-11T00:11:58.93Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/45/34/942cc95ca4e26489875aa8a95192766247a687379ec29543eebe73ec945f/pywinpty-3.0.5-cp312-cp312-win_amd64.whl", hash = "sha256:d62946adf14b15b54c0b8d785f93fe18b04da23f4ad59e2e8c4612646e9abd23", size = 2090915, upload-time = "2026-06-10T23:43:14.98Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/5b9053004844139ea8bd86209c57ade12b134b2782f383a095784c8531ec/pywinpty-3.0.5-cp312-cp312-win_arm64.whl", hash = "sha256:e9391c05fbfa7a992a97e831fc6849887b4014a614192e3d984a7ca59592b376", size = 815934, upload-time = "2026-06-10T23:41:42.384Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/2a464b9893cceb3b3f416356e94fdc3e1bca9476993927e4e6d99fe95382/pywinpty-3.0.5-cp313-cp313-win_amd64.whl", hash = "sha256:48db1b0ad9d0a1b81dcaaa7163a99a7808deaceb0c1b2344716dc1fc090c3c4c", size = 2090471, upload-time = "2026-06-10T23:42:11.071Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2c/a138491a0afbdb50eb79395577bd326d4b0fbde7209417d1a8087ff2493a/pywinpty-3.0.5-cp313-cp313-win_arm64.whl", hash = "sha256:2c6008fb2d3774b48693b2fcb7f2cc317ade9dc581289a964ffeeaf81307c9b5", size = 815518, upload-time = "2026-06-10T23:42:02.363Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/15/54400049a380582acd1282665c70fcf11e0bd3713679aca78e24c3aae738/pywinpty-3.0.5-cp313-cp313t-win_amd64.whl", hash = "sha256:22ce1b780d89821cc52daf6eac0708af22d93d000ce9c7c07e37489db8594598", size = 2089920, upload-time = "2026-06-10T23:44:13.395Z" },
+    { url = "https://files.pythonhosted.org/packages/94/0c/6f24f3c0799f502259b24bdf841a99ad2b0d59df5c2525b4e2a286d14be2/pywinpty-3.0.5-cp313-cp313t-win_arm64.whl", hash = "sha256:9c2919a81bc5cfb09b86fc5a002112b2de95ca4304a07413cbeeb746a1307a5c", size = 814520, upload-time = "2026-06-10T23:43:28.588Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/23/f3cd1b1e5fc56517f54452c49f92049e7dd9ffc8a63de22a495581f50d04/pywinpty-3.0.5-cp314-cp314-win_amd64.whl", hash = "sha256:03bb3c16d691d9242267201830bcd0e64a9b663170e9042bc84b210da9de15ac", size = 2090663, upload-time = "2026-06-10T23:43:59.845Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/dd/96d6cbfc6d9ddab5c1c2f92c26545ae8997446a2ba7ee2024cd43c81f49b/pywinpty-3.0.5-cp314-cp314-win_arm64.whl", hash = "sha256:89c5c6ef08997a3b4b277b214a35fe15cab4dd6d119f0140aa71df5b1168fdbc", size = 815700, upload-time = "2026-06-10T23:40:50.001Z" },
+    { url = "https://files.pythonhosted.org/packages/30/36/d98087bce0acaa4cce7f196103cfa7be3f63ce65f52473bb3e38784ae5d9/pywinpty-3.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:7b566165e0c5fdd6abe167a5ac8b954be6a843eb55a85946576d6bc1dea03d6d", size = 2090093, upload-time = "2026-06-10T23:40:58.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/fd/fe2b0db922ba052ce3976a08f3fc05d0c05047c8b4ebb6102e832b8ef563/pywinpty-3.0.5-cp314-cp314t-win_arm64.whl", hash = "sha256:24366280a8aa677323da87bec729cb3ea3b35367386cece0978bdc6e4695c690", size = 814517, upload-time = "2026-06-10T23:42:34.946Z" },
 ]
 
 [[package]]
@@ -1614,6 +2147,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "rfc3339-validator"
+version = "0.1.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/28/ea/a9387748e2d111c3c2b275ba970b735e04e15cdb1eb30693b6b5708c4dbd/rfc3339_validator-0.1.4.tar.gz", hash = "sha256:138a2abdf93304ad60530167e51d2dfb9549521a836871b88d7f4695d0022f6b", size = 5513, upload-time = "2021-05-12T16:37:54.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/44/4e421b96b67b2daff264473f7465db72fbdf36a07e05494f50300cc7b0c6/rfc3339_validator-0.1.4-py2.py3-none-any.whl", hash = "sha256:24f6ec1eda14ef823da9e36ec7113124b39c04d50a4d3d3a3c2859577e7791fa", size = 3490, upload-time = "2021-05-12T16:37:52.536Z" },
+]
+
+[[package]]
+name = "rfc3986-validator"
+version = "0.1.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/88/f270de456dd7d11dcc808abfa291ecdd3f45ff44e3b549ffa01b126464d0/rfc3986_validator-0.1.1.tar.gz", hash = "sha256:3d44bde7921b3b9ec3ae4e3adca370438eccebc676456449b145d533b240d055", size = 6760, upload-time = "2019-10-28T16:00:19.144Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9e/51/17023c0f8f1869d8806b979a2bffa3f861f26a3f1a66b094288323fba52f/rfc3986_validator-0.1.1-py2.py3-none-any.whl", hash = "sha256:2f235c432ef459970b4306369336b9d5dbdda31b510ca1e327636e01f528bfa9", size = 4242, upload-time = "2019-10-28T16:00:13.976Z" },
+]
+
+[[package]]
+name = "rfc3987-syntax"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "lark" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
 ]
 
 [[package]]
@@ -1759,6 +2325,15 @@ wheels = [
 ]
 
 [[package]]
+name = "send2trash"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c5/f0/184b4b5f8d00f2a92cf96eec8967a3d550b52cf94362dad1100df9e48d57/send2trash-2.1.0.tar.gz", hash = "sha256:1c72b39f09457db3c05ce1d19158c2cbef4c32b8bedd02c155e49282b7ea7459", size = 17255, upload-time = "2026-01-14T06:27:36.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/78/504fdd027da3b84ff1aecd9f6957e65f35134534ccc6da8628eb71e76d3f/send2trash-2.1.0-py3-none-any.whl", hash = "sha256:0da2f112e6d6bb22de6aa6daa7e144831a4febf2a87261451c4ad849fe9a873c", size = 17610, upload-time = "2026-01-14T06:27:35.218Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1895,6 +2470,20 @@ wheels = [
 ]
 
 [[package]]
+name = "terminado"
+version = "0.18.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ptyprocess", marker = "os_name != 'nt'" },
+    { name = "pywinpty", marker = "os_name == 'nt'" },
+    { name = "tornado" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8a/11/965c6fd8e5cc254f1fe142d547387da17a8ebfd75a3455f637c663fb38a0/terminado-0.18.1.tar.gz", hash = "sha256:de09f2c4b85de4765f7714688fff57d3e75bad1f909b589fde880460c753fd2e", size = 32701, upload-time = "2024-03-12T14:34:39.026Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/9e/2064975477fdc887e47ad42157e214526dcad8f317a948dee17e1659a62f/terminado-0.18.1-py3-none-any.whl", hash = "sha256:a4468e1b37bb318f8a86514f65814e1afc977cf29b3992a4500d9dd305dcceb0", size = 14154, upload-time = "2024-03-12T14:34:36.569Z" },
+]
+
+[[package]]
 name = "tinycss2"
 version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1953,6 +2542,15 @@ wheels = [
 ]
 
 [[package]]
+name = "uri-template"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/c7/0336f2bd0bcbada6ccef7aaa25e443c118a704f828a0620c6fa0207c1b64/uri-template-1.3.0.tar.gz", hash = "sha256:0e00f8eb65e18c7de20d595a14336e9f337ead580c70934141624b6d1ffdacc7", size = 21678, upload-time = "2023-06-21T01:49:05.374Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/00/3fca040d7cf8a32776d3d81a00c8ee7457e00f80c649f1e4a863c8321ae9/uri_template-1.3.0-py3-none-any.whl", hash = "sha256:a44a133ea12d44a0c0f06d7d42a52d71282e77e2f937d8abd5655b8d56fc1363", size = 11140, upload-time = "2023-06-21T01:49:03.467Z" },
+]
+
+[[package]]
 name = "urllib3"
 version = "2.6.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1985,10 +2583,37 @@ wheels = [
 ]
 
 [[package]]
+name = "webcolors"
+version = "25.10.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/7a/eb316761ec35664ea5174709a68bbd3389de60d4a1ebab8808bfc264ed67/webcolors-25.10.0.tar.gz", hash = "sha256:62abae86504f66d0f6364c2a8520de4a0c47b80c03fc3a5f1815fedbef7c19bf", size = 53491, upload-time = "2025-10-31T07:51:03.977Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e2/cc/e097523dd85c9cf5d354f78310927f1656c422bd7b2613b2db3e3f9a0f2c/webcolors-25.10.0-py3-none-any.whl", hash = "sha256:032c727334856fc0b968f63daa252a1ac93d33db2f5267756623c210e57a4f1d", size = 14905, upload-time = "2025-10-31T07:51:01.778Z" },
+]
+
+[[package]]
 name = "webencodings"
 version = "0.5.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0b/02/ae6ceac1baeda530866a85075641cec12989bd8d31af6d5ab4a3e8c92f47/webencodings-0.5.1.tar.gz", hash = "sha256:b36a1c245f2d304965eb4e0a82848379241dc04b865afcc4aab16748587e1923", size = 9721, upload-time = "2017-04-05T20:21:34.189Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/24/2a3e3df732393fed8b3ebf2ec078f05546de641fe1b667ee316ec1dcf3b7/webencodings-0.5.1-py2.py3-none-any.whl", hash = "sha256:a0af1213f3c2226497a97e2b3aa01a7e4bee4f403f95be16fc9acd2947514a78", size = 11774, upload-time = "2017-04-05T20:21:32.581Z" },
+]
+
+[[package]]
+name = "websocket-client"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/41/aa4bf9664e4cda14c3b39865b12251e8e7d239f4cd0e3cc1b6c2ccde25c1/websocket_client-1.9.0.tar.gz", hash = "sha256:9e813624b6eb619999a97dc7958469217c3176312b3a16a4bd1bc7e08a46ec98", size = 70576, upload-time = "2025-10-07T21:16:36.495Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/34/db/b10e48aa8fff7407e67470363eac595018441cf32d5e1001567a7aeba5d2/websocket_client-1.9.0-py3-none-any.whl", hash = "sha256:af248a825037ef591efbf6ed20cc5faa03d3b47b9e5a2230a529eeee1c1fc3ef", size = 82616, upload-time = "2025-10-07T21:16:34.951Z" },
+]
+
+[[package]]
+name = "widgetsnbextension"
+version = "4.0.15"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/f4/c67440c7fb409a71b7404b7aefcd7569a9c0d6bd071299bf4198ae7a5d95/widgetsnbextension-4.0.15.tar.gz", hash = "sha256:de8610639996f1567952d763a5a41af8af37f2575a41f9852a38f947eb82a3b9", size = 1097402, upload-time = "2025-11-01T21:15:55.178Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/0e/fa3b193432cfc60c93b42f3be03365f5f909d2b3ea410295cf36df739e31/widgetsnbextension-4.0.15-py3-none-any.whl", hash = "sha256:8156704e4346a571d9ce73b84bee86a29906c9abfd7223b7228a28899ccf3366", size = 2196503, upload-time = "2025-11-01T21:15:53.565Z" },
 ]


### PR DESCRIPTION
This PR implements some of Bryna's suggestions from her code review. A few notes: 
- 7ff06826fbfebf81bca4d70c756d7eb3c1902a4c: This fixes a bug with the test for selecting lowest delta square. The assertion that was previously being made was trivial (and incorrect).
- 7d1ffa67311b9beb0604baa5782c314d9cace300: I improve z-masking a bit to mirror that of k-masking (i.e. accepting masking functions). Also, I realized that doing `select_closest_z` when you have multiple `z_tags` with the same $z$ did not work as intended (i.e., if I do closest to `z=7` for HERA2023, it should give me all five fields instead of only Field A). This is fixed now.
- 7ce8bd3c0cab4fb142d225e4bfd0866b7688ce5a: A much needed functionality. You can now pass `collapse_z_tags=True` to `select_lowest_delta_squared` and it basically picks the lowest limit for a given $z$ across different `z_tags`.

## Summary by Sourcery

Improve dataset selection, plotting labels, and documentation based on review feedback.

New Features:
- Allow selecting lowest delta-squared values while collapsing across z-tags for each redshift.
- Support loading arbitrary YAML datasets directly in k-space plotting utilities.
- Unify LaTeX label generation for limits and theory datasets via a single helper.

Bug Fixes:
- Correct closest-z selection to return all entries at the nearest redshift when multiple z-tags share the same z.
- Fix tests for closest z/k selection and lowest delta-squared to assert non-trivial, correct behavior.
- Correct year and note text in Beardsley2016 and Kolopanis2019 dataset metadata.

Enhancements:
- Generalize z-based selection to accept functional masks and align behavior with k-based masking.
- Improve legend label formatting for theory curves and validate conflicting style options in plotting.
- Clarify documentation on using local YAML files and new collapse_z_tags behavior in the tutorial.

Documentation:
- Update tutorial and README to describe loading local YAML datasets and the collapse_z_tags option.
- Adjust docs build dependencies for Jupyter-based notebooks and clean up notebook metadata.

Tests:
- Extend datatypes tests to cover collapse_z_tags behavior and more robust closest value selection semantics.